### PR TITLE
feat(observatory): O1 inventory scanner (psdl_observatory)

### DIFF
--- a/backend/psdl_observatory/README.md
+++ b/backend/psdl_observatory/README.md
@@ -1,0 +1,12 @@
+# psdl-observatory
+
+EDW Observatory (O1): metadata-only inventory scanner for healthcare parquet
+lakes. Reads parquet footers only — never row data, never PHI — and emits a
+filesystem inventory, duplicate-filename report, scan summary, and static HTML.
+
+File identity is `relative_path + schema_signature`, not filename (filenames
+like `deid_notes_cleaned_0.parquet` recur across datasets and are not globally
+meaningful).
+
+Inspector ships the full scanner + CLI + HTML report. PSDL Workbench consumes
+these core APIs and adds institutional/enhanced functions.

--- a/backend/psdl_observatory/__init__.py
+++ b/backend/psdl_observatory/__init__.py
@@ -1,0 +1,34 @@
+"""psdl_observatory — metadata-only EDW parquet-lake inventory scanner.
+
+Reads parquet footers only (no row data, no PHI). Public API:
+    scan_inventory(root, workers=...) -> ScanResult
+    write_all(scan_result, out_dir) -> dict[str, Path]
+    render_html_report(scan_result) -> str
+"""
+
+__version__ = "0.1.0"
+
+from psdl_observatory.models import ParquetFileInfo, ScanResult
+from psdl_observatory.scanner import read_parquet_footer, scan_inventory
+from psdl_observatory.schema_sig import normalize_columns, schema_signature
+from psdl_observatory.writers import (
+    write_all,
+    write_duplicates_csv,
+    write_inventory_csv,
+    write_summary_txt,
+)
+from psdl_observatory.report import render_html_report
+
+__all__ = [
+    "ParquetFileInfo",
+    "ScanResult",
+    "read_parquet_footer",
+    "scan_inventory",
+    "normalize_columns",
+    "schema_signature",
+    "write_all",
+    "write_inventory_csv",
+    "write_duplicates_csv",
+    "write_summary_txt",
+    "render_html_report",
+]

--- a/backend/psdl_observatory/__init__.py
+++ b/backend/psdl_observatory/__init__.py
@@ -8,38 +8,16 @@ Reads parquet footers only (no row data, no PHI). Public API:
 
 __version__ = "0.1.0"
 
-# Submodules are imported lazily so the package stays importable during
-# incremental TDD (each task adds one module; __init__ re-exports whatever is
-# available).  Once all modules exist (Tasks 0-6 complete) every name is live.
-try:
-    from psdl_observatory.models import ParquetFileInfo, ScanResult
-except ImportError:
-    pass
-
-try:
-    from psdl_observatory.scanner import read_parquet_footer, scan_inventory
-except ImportError:
-    pass
-
-try:
-    from psdl_observatory.schema_sig import normalize_columns, schema_signature
-except ImportError:
-    pass
-
-try:
-    from psdl_observatory.writers import (
-        write_all,
-        write_duplicates_csv,
-        write_inventory_csv,
-        write_summary_txt,
-    )
-except ImportError:
-    pass
-
-try:
-    from psdl_observatory.report import render_html_report
-except ImportError:
-    pass
+from psdl_observatory.models import ParquetFileInfo, ScanResult
+from psdl_observatory.scanner import read_parquet_footer, scan_inventory
+from psdl_observatory.schema_sig import normalize_columns, schema_signature
+from psdl_observatory.writers import (
+    write_all,
+    write_duplicates_csv,
+    write_inventory_csv,
+    write_summary_txt,
+)
+from psdl_observatory.report import render_html_report
 
 __all__ = [
     "ParquetFileInfo",

--- a/backend/psdl_observatory/__init__.py
+++ b/backend/psdl_observatory/__init__.py
@@ -8,16 +8,38 @@ Reads parquet footers only (no row data, no PHI). Public API:
 
 __version__ = "0.1.0"
 
-from psdl_observatory.models import ParquetFileInfo, ScanResult
-from psdl_observatory.scanner import read_parquet_footer, scan_inventory
-from psdl_observatory.schema_sig import normalize_columns, schema_signature
-from psdl_observatory.writers import (
-    write_all,
-    write_duplicates_csv,
-    write_inventory_csv,
-    write_summary_txt,
-)
-from psdl_observatory.report import render_html_report
+# Submodules are imported lazily so the package stays importable during
+# incremental TDD (each task adds one module; __init__ re-exports whatever is
+# available).  Once all modules exist (Tasks 0-6 complete) every name is live.
+try:
+    from psdl_observatory.models import ParquetFileInfo, ScanResult
+except ImportError:
+    pass
+
+try:
+    from psdl_observatory.scanner import read_parquet_footer, scan_inventory
+except ImportError:
+    pass
+
+try:
+    from psdl_observatory.schema_sig import normalize_columns, schema_signature
+except ImportError:
+    pass
+
+try:
+    from psdl_observatory.writers import (
+        write_all,
+        write_duplicates_csv,
+        write_inventory_csv,
+        write_summary_txt,
+    )
+except ImportError:
+    pass
+
+try:
+    from psdl_observatory.report import render_html_report
+except ImportError:
+    pass
 
 __all__ = [
     "ParquetFileInfo",

--- a/backend/psdl_observatory/cli.py
+++ b/backend/psdl_observatory/cli.py
@@ -23,11 +23,11 @@ def _cmd_scan(args: argparse.Namespace) -> int:
     if args.workers < 1:
         print(f"error: --workers must be >= 1, got {args.workers}", file=sys.stderr)
         return 2
-    result = scan_inventory(root, workers=args.workers)
     out_dir = Path(args.out)
     if out_dir.exists() and not out_dir.is_dir():
         print(f"error: --out exists and is not a directory: {out_dir}", file=sys.stderr)
         return 2
+    result = scan_inventory(root, workers=args.workers)
     paths = write_all(result, out_dir)
     if args.html:
         html_path = out_dir / "inventory.html"

--- a/backend/psdl_observatory/cli.py
+++ b/backend/psdl_observatory/cli.py
@@ -1,0 +1,52 @@
+"""`psdl-observatory` command-line entry point.
+
+    psdl-observatory scan <root> --out <dir> [--html] [--workers N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+from psdl_observatory.report import render_html_report
+from psdl_observatory.scanner import scan_inventory
+from psdl_observatory.writers import write_all
+
+
+def _cmd_scan(args: argparse.Namespace) -> int:
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"error: not a directory: {root}", file=sys.stderr)
+        return 2
+    result = scan_inventory(root, workers=args.workers)
+    out_dir = Path(args.out)
+    paths = write_all(result, out_dir)
+    if args.html:
+        html_path = out_dir / "inventory.html"
+        html_path.write_text(render_html_report(result))
+        paths["html"] = html_path
+    print(f"scanned {result.total_files} parquet files, "
+          f"{result.total_rows} rows, {result.distinct_schema_count} distinct schemas, "
+          f"{len(result.errors)} errors")
+    for label, p in paths.items():
+        print(f"  {label}: {p}")
+    return 0
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="psdl-observatory")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p_scan = sub.add_parser("scan", help="Scan a parquet lake (footers only) and write the inventory")
+    p_scan.add_argument("root", help="Root directory of the parquet lake")
+    p_scan.add_argument("--out", required=True, help="Output directory for the inventory artifacts")
+    p_scan.add_argument("--html", action="store_true", help="Also write inventory.html")
+    p_scan.add_argument("--workers", type=int, default=8, help="Parallel footer-read workers (default 8)")
+    p_scan.set_defaults(func=_cmd_scan)
+    ns = parser.parse_args(list(argv) if argv is not None else None)
+    return ns.func(ns)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/backend/psdl_observatory/cli.py
+++ b/backend/psdl_observatory/cli.py
@@ -20,8 +20,14 @@ def _cmd_scan(args: argparse.Namespace) -> int:
     if not root.is_dir():
         print(f"error: not a directory: {root}", file=sys.stderr)
         return 2
+    if args.workers < 1:
+        print(f"error: --workers must be >= 1, got {args.workers}", file=sys.stderr)
+        return 2
     result = scan_inventory(root, workers=args.workers)
     out_dir = Path(args.out)
+    if out_dir.exists() and not out_dir.is_dir():
+        print(f"error: --out exists and is not a directory: {out_dir}", file=sys.stderr)
+        return 2
     paths = write_all(result, out_dir)
     if args.html:
         html_path = out_dir / "inventory.html"

--- a/backend/psdl_observatory/models.py
+++ b/backend/psdl_observatory/models.py
@@ -53,7 +53,11 @@ class ScanResult:
         return len({f.schema_signature for f in self.files})
 
     def duplicate_filenames(self) -> Dict[str, List[str]]:
-        """Basenames that occur at more than one relative path -> sorted paths."""
+        """Basenames that occur at more than one relative path → sorted paths.
+
+        Assumes each ParquetFileInfo.relative_path is unique within
+        self.files (the scanner guarantees this — os.walk yields each path once).
+        """
         by_name: Dict[str, List[str]] = defaultdict(list)
         for f in self.files:
             by_name[f.filename].append(f.relative_path)

--- a/backend/psdl_observatory/models.py
+++ b/backend/psdl_observatory/models.py
@@ -1,0 +1,64 @@
+"""Data models for the Observatory inventory scan."""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+
+@dataclass(frozen=True)
+class ParquetFileInfo:
+    """Footer-derived metadata for a single parquet file. No row data."""
+
+    relative_path: str
+    size_bytes: int
+    num_rows: int
+    num_row_groups: int
+    columns: Tuple[str, ...]
+    schema_signature: str
+
+    @property
+    def num_columns(self) -> int:
+        return len(self.columns)
+
+    @property
+    def filename(self) -> str:
+        return os.path.basename(self.relative_path)
+
+
+@dataclass
+class ScanResult:
+    """Aggregate result of scanning a parquet lake."""
+
+    root: str
+    files: List[ParquetFileInfo]
+    errors: List[Tuple[str, str]] = field(default_factory=list)  # (relative_path, message)
+
+    @property
+    def total_files(self) -> int:
+        return len(self.files)
+
+    @property
+    def total_rows(self) -> int:
+        return sum(f.num_rows for f in self.files)
+
+    @property
+    def total_size_bytes(self) -> int:
+        return sum(f.size_bytes for f in self.files)
+
+    @property
+    def distinct_schema_count(self) -> int:
+        return len({f.schema_signature for f in self.files})
+
+    def duplicate_filenames(self) -> Dict[str, List[str]]:
+        """Basenames that occur at more than one relative path -> sorted paths."""
+        by_name: Dict[str, List[str]] = defaultdict(list)
+        for f in self.files:
+            by_name[f.filename].append(f.relative_path)
+        return {
+            name: sorted(paths)
+            for name, paths in by_name.items()
+            if len(paths) > 1
+        }

--- a/backend/psdl_observatory/models.py
+++ b/backend/psdl_observatory/models.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class ParquetFileInfo:
     """Footer-derived metadata for a single parquet file. No row data."""
 

--- a/backend/psdl_observatory/pyproject.toml
+++ b/backend/psdl_observatory/pyproject.toml
@@ -22,3 +22,9 @@ psdl-observatory = "psdl_observatory.cli:main"
 [tool.setuptools]
 packages = ["psdl_observatory"]
 package-dir = {"psdl_observatory" = "."}
+
+[tool.pytest.ini_options]
+# importlib mode lets individual submodule tests run without triggering the
+# package __init__.py (which imports all submodules). This supports incremental
+# TDD: each task's test file can run as soon as that module is created.
+addopts = "--import-mode=importlib"

--- a/backend/psdl_observatory/pyproject.toml
+++ b/backend/psdl_observatory/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "psdl-observatory"
+version = "0.1.0"
+description = "EDW Observatory: metadata-only parquet-lake inventory scanner for the PSDL ecosystem."
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "MIT"}
+dependencies = [
+    "pyarrow>=15,<17",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.4.0"]
+
+[project.scripts]
+psdl-observatory = "psdl_observatory.cli:main"
+
+[tool.setuptools]
+packages = ["psdl_observatory"]
+package-dir = {"psdl_observatory" = "."}

--- a/backend/psdl_observatory/report.py
+++ b/backend/psdl_observatory/report.py
@@ -1,0 +1,69 @@
+"""Render a self-contained static HTML report from a ScanResult.
+
+Single-file HTML (inline CSS, no JS deps) so it can be opened directly or
+bundled with the scan output. All dynamic text is HTML-escaped.
+"""
+
+from __future__ import annotations
+
+from html import escape
+
+from psdl_observatory.models import ScanResult
+
+
+def render_html_report(result: ScanResult) -> str:
+    rows = "\n".join(
+        "<tr>"
+        f"<td>{escape(f.relative_path)}</td>"
+        f"<td>{f.num_rows}</td>"
+        f"<td>{f.num_row_groups}</td>"
+        f"<td>{f.num_columns}</td>"
+        f"<td><code>{escape(f.schema_signature)}</code></td>"
+        f"<td>{escape('|'.join(f.columns))}</td>"
+        "</tr>"
+        for f in result.files
+    )
+    dup_rows = "\n".join(
+        f"<tr><td>{escape(name)}</td><td>{len(paths)}</td><td>{escape(', '.join(paths))}</td></tr>"
+        for name, paths in sorted(result.duplicate_filenames().items())
+    ) or '<tr><td colspan="3">none</td></tr>'
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>PSDL Observatory — Inventory</title>
+<style>
+ body {{ font-family: -apple-system, system-ui, sans-serif; margin: 2rem; color: #1a1a1a; }}
+ h1 {{ font-size: 1.4rem; }}
+ .stats {{ display: flex; gap: 2rem; margin: 1rem 0; flex-wrap: wrap; }}
+ .stat {{ background: #f4f4f7; border-radius: 8px; padding: 0.75rem 1rem; }}
+ .stat b {{ display: block; font-size: 1.5rem; }}
+ table {{ border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: 0.85rem; }}
+ th, td {{ border: 1px solid #ddd; padding: 4px 8px; text-align: left; }}
+ th {{ background: #f0f0f3; }}
+ code {{ font-size: 0.8rem; }}
+</style>
+</head>
+<body>
+<h1>PSDL Observatory — Inventory Scan</h1>
+<p>Root: <code>{escape(result.root)}</code></p>
+<div class="stats">
+  <div class="stat"><b>{result.total_files}</b>Total files</div>
+  <div class="stat"><b>{result.total_rows}</b>Total rows</div>
+  <div class="stat"><b>{result.distinct_schema_count}</b>Distinct schemas</div>
+  <div class="stat"><b>{len(result.duplicate_filenames())}</b>Duplicate filenames</div>
+  <div class="stat"><b>{len(result.errors)}</b>Errors</div>
+</div>
+<h2>Files</h2>
+<table>
+<tr><th>Relative path</th><th>Rows</th><th>Row groups</th><th>Cols</th><th>Schema sig</th><th>Columns</th></tr>
+{rows}
+</table>
+<h2>Duplicate filenames</h2>
+<table>
+<tr><th>Filename</th><th>Count</th><th>Paths</th></tr>
+{dup_rows}
+</table>
+</body>
+</html>
+"""

--- a/backend/psdl_observatory/report.py
+++ b/backend/psdl_observatory/report.py
@@ -12,6 +12,7 @@ from psdl_observatory.models import ScanResult
 
 
 def render_html_report(result: ScanResult) -> str:
+    dups = result.duplicate_filenames()
     rows = "\n".join(
         "<tr>"
         f"<td>{escape(f.relative_path)}</td>"
@@ -25,7 +26,7 @@ def render_html_report(result: ScanResult) -> str:
     )
     dup_rows = "\n".join(
         f"<tr><td>{escape(name)}</td><td>{len(paths)}</td><td>{escape(', '.join(paths))}</td></tr>"
-        for name, paths in sorted(result.duplicate_filenames().items())
+        for name, paths in sorted(dups.items())
     ) or '<tr><td colspan="3">none</td></tr>'
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -51,7 +52,7 @@ def render_html_report(result: ScanResult) -> str:
   <div class="stat"><b>{result.total_files}</b>Total files</div>
   <div class="stat"><b>{result.total_rows}</b>Total rows</div>
   <div class="stat"><b>{result.distinct_schema_count}</b>Distinct schemas</div>
-  <div class="stat"><b>{len(result.duplicate_filenames())}</b>Duplicate filenames</div>
+  <div class="stat"><b>{len(dups)}</b>Duplicate filenames</div>
   <div class="stat"><b>{len(result.errors)}</b>Errors</div>
 </div>
 <h2>Files</h2>

--- a/backend/psdl_observatory/scanner.py
+++ b/backend/psdl_observatory/scanner.py
@@ -1,0 +1,77 @@
+"""Parquet-footer inventory scanner.
+
+Reads ONLY parquet footers (metadata + schema) — never row data, never PHI.
+Parallelized with ThreadPoolExecutor (footer reads are I/O-bound).
+"""
+
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import List, Tuple, Union
+
+import pyarrow.parquet as pq
+
+from psdl_observatory.models import ParquetFileInfo, ScanResult
+from psdl_observatory.schema_sig import schema_signature
+
+
+def _find_parquet_files(root: Path) -> List[Path]:
+    out: List[Path] = []
+    for dirpath, _dirs, filenames in os.walk(root):
+        for name in filenames:
+            if name.endswith(".parquet"):
+                out.append(Path(dirpath) / name)
+    return out
+
+
+def read_parquet_footer(path: Union[str, Path], root: Union[str, Path]) -> ParquetFileInfo:
+    """Read one parquet file's footer (no rows) into a ParquetFileInfo."""
+    path = Path(path)
+    root = Path(root)
+    md = pq.read_metadata(path)          # footer only
+    schema = pq.read_schema(path)        # footer only
+    columns = tuple(schema.names)
+    types = [str(schema.field(n).type) for n in schema.names]
+    rel = str(path.relative_to(root))
+    return ParquetFileInfo(
+        relative_path=rel,
+        size_bytes=path.stat().st_size,
+        num_rows=md.num_rows,
+        num_row_groups=md.num_row_groups,
+        columns=columns,
+        schema_signature=schema_signature(list(columns), types),
+    )
+
+
+def scan_inventory(
+    root: Union[str, Path],
+    workers: int = 8,
+) -> ScanResult:
+    """Walk `root` for *.parquet, read footers in parallel, return a ScanResult.
+
+    Footer-read failures (corrupt / non-parquet files) are collected in
+    ScanResult.errors rather than aborting the scan.
+    """
+    root = Path(root)
+    files = _find_parquet_files(root)
+    infos: List[ParquetFileInfo] = []
+    errors: List[Tuple[str, str]] = []
+
+    if not files:
+        return ScanResult(root=str(root), files=infos, errors=errors)
+
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futures = {ex.submit(read_parquet_footer, p, root): p for p in files}
+        for fut in as_completed(futures):
+            p = futures[fut]
+            try:
+                infos.append(fut.result())
+            except Exception as e:  # corrupt/unreadable footer
+                rel = str(Path(p).relative_to(root))
+                errors.append((rel, f"{type(e).__name__}: {e}"))
+
+    infos.sort(key=lambda i: i.relative_path)
+    errors.sort()
+    return ScanResult(root=str(root), files=infos, errors=errors)

--- a/backend/psdl_observatory/scanner.py
+++ b/backend/psdl_observatory/scanner.py
@@ -19,6 +19,9 @@ from psdl_observatory.schema_sig import schema_signature
 
 def _find_parquet_files(root: Path) -> List[Path]:
     out: List[Path] = []
+    # os.walk does not follow directory symlinks by default; symlinked dataset mounts are
+    # intentionally not traversed in O1 (avoids cycles/double-counting).
+    # followlinks support can be added later if needed.
     for dirpath, _dirs, filenames in os.walk(root):
         for name in filenames:
             if name.endswith(".parquet"):
@@ -30,14 +33,17 @@ def read_parquet_footer(path: Union[str, Path], root: Union[str, Path]) -> Parqu
     """Read one parquet file's footer (no rows) into a ParquetFileInfo."""
     path = Path(path)
     root = Path(root)
+    size_bytes = path.stat().st_size     # stat first — fail-fast before any footer read
     md = pq.read_metadata(path)          # footer only
+    # Second footer read: PyArrow has no way to derive the Arrow schema from an
+    # already-parsed FileMetaData, so this is required (don't "optimize" it away).
     schema = pq.read_schema(path)        # footer only
     columns = tuple(schema.names)
     types = [str(schema.field(n).type) for n in schema.names]
     rel = str(path.relative_to(root))
     return ParquetFileInfo(
         relative_path=rel,
-        size_bytes=path.stat().st_size,
+        size_bytes=size_bytes,
         num_rows=md.num_rows,
         num_row_groups=md.num_row_groups,
         columns=columns,
@@ -69,7 +75,7 @@ def scan_inventory(
             try:
                 infos.append(fut.result())
             except Exception as e:  # corrupt/unreadable footer
-                rel = str(Path(p).relative_to(root))
+                rel = str(p.relative_to(root))
                 errors.append((rel, f"{type(e).__name__}: {e}"))
 
     infos.sort(key=lambda i: i.relative_path)

--- a/backend/psdl_observatory/schema_sig.py
+++ b/backend/psdl_observatory/schema_sig.py
@@ -1,0 +1,28 @@
+"""Stable, order-independent schema signature.
+
+A file's identity in the Observatory is (relative_path + schema_signature),
+never its filename. The signature hashes the SET of (column, type) pairs so
+two files with the same columns in a different order get the same signature.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import List
+
+
+def normalize_columns(columns: List[str]) -> List[str]:
+    """Lowercase + strip column names (case/whitespace-insensitive identity)."""
+    return [c.strip().lower() for c in columns]
+
+
+def schema_signature(columns: List[str], types: List[str]) -> str:
+    """Return a 16-hex-char signature for a schema.
+
+    Order-independent: sorts (normalized_name, type) pairs before hashing, so
+    column order does not affect the signature.
+    """
+    norm = normalize_columns(columns)
+    pairs = sorted(zip(norm, [str(t) for t in types]))
+    blob = "|".join(f"{name}:{typ}" for name, typ in pairs)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]

--- a/backend/psdl_observatory/schema_sig.py
+++ b/backend/psdl_observatory/schema_sig.py
@@ -22,6 +22,10 @@ def schema_signature(columns: List[str], types: List[str]) -> str:
     Order-independent: sorts (normalized_name, type) pairs before hashing, so
     column order does not affect the signature.
     """
+    if len(columns) != len(types):
+        raise ValueError(
+            f"columns and types must have equal length, got {len(columns)} vs {len(types)}"
+        )
     norm = normalize_columns(columns)
     pairs = sorted(zip(norm, [str(t) for t in types]))
     blob = "|".join(f"{name}:{typ}" for name, typ in pairs)

--- a/backend/psdl_observatory/scripts/make_synthea_edw.py
+++ b/backend/psdl_observatory/scripts/make_synthea_edw.py
@@ -9,12 +9,18 @@ so the Observatory scanner has a realistic "new EDW" to inventory.
 
 Usage:
     python scripts/make_synthea_edw.py --out /tmp/synthea_edw [--shards 3]
+
+Note: this is a **dev-only helper run from source** — it is intentionally NOT
+included in the built wheel (``scripts/`` is not listed in pyproject
+``packages``), so it must be run from a source checkout.
 """
 from __future__ import annotations
 
 import argparse
 import io
+import ssl
 import sys
+import urllib.error
 import urllib.request
 import zipfile
 from pathlib import Path
@@ -30,11 +36,34 @@ SYNTHEA_SAMPLE_URL = (
 )
 
 
+def _ssl_context() -> ssl.SSLContext:
+    """Build an SSL context for the download.
+
+    Prefer certifi's CA bundle when importable, to avoid the common macOS
+    python.org ``CERTIFICATE_VERIFY_FAILED`` failure (system Python ships
+    without a populated CA store until ``Install Certificates.command`` is run).
+    Falls back to the platform default context when certifi is absent.
+    """
+    try:
+        import certifi  # noqa: PLC0415 — optional, imported lazily
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:  # pragma: no cover - certifi missing / unusable
+        return ssl.create_default_context()
+
+
 def build(out_dir: Path, shards: int = 3) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     print(f"downloading Synthea sample CSVs from {SYNTHEA_SAMPLE_URL} ...")
-    with urllib.request.urlopen(SYNTHEA_SAMPLE_URL) as resp:  # noqa: S310 (trusted URL)
-        data = resp.read()
+    try:
+        with urllib.request.urlopen(  # noqa: S310 (trusted URL)
+            SYNTHEA_SAMPLE_URL, context=_ssl_context(), timeout=60
+        ) as resp:
+            data = resp.read()
+    except urllib.error.URLError as e:
+        raise RuntimeError(
+            f"failed to download Synthea sample data from {SYNTHEA_SAMPLE_URL}: {e}"
+        ) from e
     zf = zipfile.ZipFile(io.BytesIO(data))
     csv_names = [n for n in zf.namelist() if n.lower().endswith(".csv")]
     print(f"found {len(csv_names)} CSV tables")

--- a/backend/psdl_observatory/scripts/make_synthea_edw.py
+++ b/backend/psdl_observatory/scripts/make_synthea_edw.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Build a synthetic EDW parquet lake from Synthea sample CSVs.
+
+Synthea (synthetichealth/synthea) produces fully synthetic patient records --
+no PHI, no credentialing required (contrast with MIMIC). We download the
+published sample CSV dataset and convert each table (patients, encounters,
+conditions, medications, observations, procedures, ...) to parquet, sharded,
+so the Observatory scanner has a realistic "new EDW" to inventory.
+
+Usage:
+    python scripts/make_synthea_edw.py --out /tmp/synthea_edw [--shards 3]
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.csv as pacsv
+import pyarrow.parquet as pq
+
+# Synthea public sample CSV dataset (synthetic, ~100 patients, MIT-licensed).
+SYNTHEA_SAMPLE_URL = (
+    "https://synthetichealth.github.io/synthea-sample-data/downloads/"
+    "synthea_sample_data_csv_apr2020.zip"
+)
+
+
+def build(out_dir: Path, shards: int = 3) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"downloading Synthea sample CSVs from {SYNTHEA_SAMPLE_URL} ...")
+    with urllib.request.urlopen(SYNTHEA_SAMPLE_URL) as resp:  # noqa: S310 (trusted URL)
+        data = resp.read()
+    zf = zipfile.ZipFile(io.BytesIO(data))
+    csv_names = [n for n in zf.namelist() if n.lower().endswith(".csv")]
+    print(f"found {len(csv_names)} CSV tables")
+    for name in csv_names:
+        table_name = Path(name).stem.lower()
+        with zf.open(name) as f:
+            tbl = pacsv.read_csv(f)
+        # shard each table into N parquet parts under a per-table dir
+        n = tbl.num_rows
+        if n == 0:
+            continue
+        per = max(1, (n + shards - 1) // shards)
+        tdir = out_dir / table_name
+        tdir.mkdir(parents=True, exist_ok=True)
+        for i in range(0, n, per):
+            part = tbl.slice(i, per)
+            pq.write_table(part, tdir / f"{table_name}-{i // per}.parquet")
+        print(f"  {table_name}: {n} rows -> {tdir}")
+    print(f"done: synthetic EDW parquet lake at {out_dir}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--shards", type=int, default=3)
+    a = ap.parse_args()
+    build(Path(a.out), a.shards)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/psdl_observatory/tests/conftest.py
+++ b/backend/psdl_observatory/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Synthetic parquet fixtures for Observatory scanner tests.
+
+Builds a small, hermetic parquet lake on disk (no PHI, no network) covering the
+cases that matter: nested dirs, multiple schemas, duplicate filenames across
+dirs, multi-row-group files.
+"""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+
+def _write(path, table, row_group_size=None):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(table, path, row_group_size=row_group_size)
+
+
+@pytest.fixture
+def parquet_lake(tmp_path):
+    """A synthetic parquet lake at tmp_path. Returns the root Path.
+
+    Layout:
+      EHR/labs/part-0.parquet      schema A (patient_id:int64, value:double), 100 rows, 2 row groups
+      EHR/labs/part-1.parquet      schema A, 50 rows
+      EHR/vitals/part-0.parquet    schema B (patient_id:int64, hr:int64), 30 rows  (dup basename part-0.parquet)
+      NOTES/notes-0.parquet        schema C (note_id:int64, text:string), 10 rows
+    """
+    root = tmp_path / "lake"
+
+    schema_a = pa.table(
+        {"patient_id": pa.array(range(100), pa.int64()),
+         "value": pa.array([float(i) for i in range(100)], pa.float64())}
+    )
+    _write(root / "EHR" / "labs" / "part-0.parquet", schema_a, row_group_size=50)  # 100 rows -> 2 row groups
+
+    schema_a_small = pa.table(
+        {"patient_id": pa.array(range(50), pa.int64()),
+         "value": pa.array([float(i) for i in range(50)], pa.float64())}
+    )
+    _write(root / "EHR" / "labs" / "part-1.parquet", schema_a_small)
+
+    schema_b = pa.table(
+        {"patient_id": pa.array(range(30), pa.int64()),
+         "hr": pa.array(range(30), pa.int64())}
+    )
+    _write(root / "EHR" / "vitals" / "part-0.parquet", schema_b)  # duplicate basename "part-0.parquet"
+
+    schema_c = pa.table(
+        {"note_id": pa.array(range(10), pa.int64()),
+         "text": pa.array([f"n{i}" for i in range(10)], pa.string())}
+    )
+    _write(root / "NOTES" / "notes-0.parquet", schema_c)
+
+    return root

--- a/backend/psdl_observatory/tests/test_cli.py
+++ b/backend/psdl_observatory/tests/test_cli.py
@@ -1,0 +1,36 @@
+"""Tests for the psdl-observatory CLI."""
+
+import subprocess
+import sys
+
+
+def _run(*args, cwd):
+    return subprocess.run(
+        [sys.executable, "-m", "psdl_observatory.cli", *args],
+        cwd=cwd, capture_output=True, text=True,
+    )
+
+
+def test_cli_scan_writes_outputs(parquet_lake, tmp_path):
+    out = tmp_path / "scans"
+    r = _run("scan", str(parquet_lake), "--out", str(out), cwd=tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert (out / "parquet_inventory.csv").exists()
+    assert (out / "duplicate_filenames.csv").exists()
+    assert (out / "scan_summary.txt").exists()
+    # stdout summary mentions the file count
+    assert "4" in r.stdout
+
+
+def test_cli_scan_html_flag(parquet_lake, tmp_path):
+    out = tmp_path / "scans"
+    r = _run("scan", str(parquet_lake), "--out", str(out), "--html", cwd=tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert (out / "inventory.html").exists()
+    assert "<!DOCTYPE html>" in (out / "inventory.html").read_text()
+
+
+def test_cli_help_lists_scan(tmp_path):
+    r = _run("--help", cwd=tmp_path)
+    assert r.returncode == 0
+    assert "scan" in r.stdout

--- a/backend/psdl_observatory/tests/test_cli.py
+++ b/backend/psdl_observatory/tests/test_cli.py
@@ -1,13 +1,19 @@
 """Tests for the psdl-observatory CLI."""
 
+import os
 import subprocess
 import sys
+from pathlib import Path
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent.parent  # .../backend
 
 
 def _run(*args, cwd):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(_BACKEND_DIR) + os.pathsep + env.get("PYTHONPATH", "")
     return subprocess.run(
         [sys.executable, "-m", "psdl_observatory.cli", *args],
-        cwd=cwd, capture_output=True, text=True,
+        cwd=cwd, capture_output=True, text=True, env=env,
     )
 
 
@@ -19,7 +25,7 @@ def test_cli_scan_writes_outputs(parquet_lake, tmp_path):
     assert (out / "duplicate_filenames.csv").exists()
     assert (out / "scan_summary.txt").exists()
     # stdout summary mentions the file count
-    assert "4" in r.stdout
+    assert "scanned 4 parquet files" in r.stdout
 
 
 def test_cli_scan_html_flag(parquet_lake, tmp_path):
@@ -34,3 +40,17 @@ def test_cli_help_lists_scan(tmp_path):
     r = _run("--help", cwd=tmp_path)
     assert r.returncode == 0
     assert "scan" in r.stdout
+
+
+def test_cli_workers_zero_errors(parquet_lake, tmp_path):
+    r = _run("scan", str(parquet_lake), "--out", str(tmp_path / "scans"), "--workers", "0", cwd=tmp_path)
+    assert r.returncode == 2
+    assert "workers must be >= 1" in r.stderr
+
+
+def test_cli_out_is_file_errors(parquet_lake, tmp_path):
+    bad_out = tmp_path / "afile"
+    bad_out.write_text("x")
+    r = _run("scan", str(parquet_lake), "--out", str(bad_out), cwd=tmp_path)
+    assert r.returncode == 2
+    assert "not a directory" in r.stderr

--- a/backend/psdl_observatory/tests/test_models.py
+++ b/backend/psdl_observatory/tests/test_models.py
@@ -1,0 +1,37 @@
+"""Tests for psdl_observatory.models."""
+
+from psdl_observatory.models import ParquetFileInfo, ScanResult
+
+
+def test_parquet_file_info_fields():
+    info = ParquetFileInfo(
+        relative_path="EHR/labs/part-0.parquet",
+        size_bytes=1024,
+        num_rows=100,
+        num_row_groups=2,
+        columns=("patient_id", "value"),
+        schema_signature="abc123",
+    )
+    assert info.relative_path == "EHR/labs/part-0.parquet"
+    assert info.size_bytes == 1024
+    assert info.num_rows == 100
+    assert info.num_row_groups == 2
+    assert info.columns == ("patient_id", "value")
+    assert info.num_columns == 2
+    assert info.filename == "part-0.parquet"
+
+
+def test_scan_result_aggregates():
+    files = [
+        ParquetFileInfo("a/x.parquet", 10, 5, 1, ("p", "v"), "sig1"),
+        ParquetFileInfo("b/x.parquet", 20, 7, 1, ("p", "v"), "sig1"),
+        ParquetFileInfo("c/y.parquet", 30, 3, 1, ("p",), "sig2"),
+    ]
+    r = ScanResult(root="/data", files=files, errors=[])
+    assert r.total_files == 3
+    assert r.total_rows == 15
+    assert r.total_size_bytes == 60
+    assert r.distinct_schema_count == 2
+    # duplicate basename "x.parquet" appears at a/x and b/x
+    dups = r.duplicate_filenames()
+    assert dups == {"x.parquet": ["a/x.parquet", "b/x.parquet"]}

--- a/backend/psdl_observatory/tests/test_report.py
+++ b/backend/psdl_observatory/tests/test_report.py
@@ -1,0 +1,33 @@
+"""Tests for the static HTML inventory report."""
+
+from psdl_observatory.models import ParquetFileInfo, ScanResult
+from psdl_observatory.report import render_html_report
+
+
+def _result():
+    files = [
+        ParquetFileInfo("EHR/labs/part-0.parquet", 100, 100, 2, ("patient_id", "value"), "sigA"),
+        ParquetFileInfo("EHR/vitals/part-0.parquet", 60, 30, 1, ("patient_id", "hr"), "sigB"),
+    ]
+    return ScanResult(root="/data/lake", files=files, errors=[])
+
+
+def test_report_is_html():
+    html = render_html_report(_result())
+    assert html.lstrip().startswith("<!DOCTYPE html>")
+    assert "</html>" in html
+
+
+def test_report_includes_totals_and_files():
+    html = render_html_report(_result())
+    assert "Total files" in html
+    assert "2" in html  # total files
+    assert "EHR/labs/part-0.parquet" in html
+    assert "sigA" in html
+
+
+def test_report_escapes_html_in_paths():
+    files = [ParquetFileInfo("weird/<script>.parquet", 1, 1, 1, ("a",), "s")]
+    html = render_html_report(ScanResult(root="/r", files=files, errors=[]))
+    assert "<script>.parquet" not in html       # raw tag must not appear
+    assert "&lt;script&gt;.parquet" in html      # escaped form present

--- a/backend/psdl_observatory/tests/test_report.py
+++ b/backend/psdl_observatory/tests/test_report.py
@@ -21,7 +21,7 @@ def test_report_is_html():
 def test_report_includes_totals_and_files():
     html = render_html_report(_result())
     assert "Total files" in html
-    assert "2" in html  # total files
+    assert ">2</b>Total files" in html
     assert "EHR/labs/part-0.parquet" in html
     assert "sigA" in html
 

--- a/backend/psdl_observatory/tests/test_scanner.py
+++ b/backend/psdl_observatory/tests/test_scanner.py
@@ -1,0 +1,54 @@
+"""Tests for the parquet-footer scanner."""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from psdl_observatory.scanner import read_parquet_footer, scan_inventory
+
+
+def test_read_footer_single_file(tmp_path):
+    p = tmp_path / "sub" / "f.parquet"
+    p.parent.mkdir(parents=True)
+    pq.write_table(
+        pa.table({"patient_id": pa.array([1, 2], pa.int64()),
+                  "value": pa.array([1.0, 2.0], pa.float64())}),
+        p, row_group_size=1,
+    )
+    info = read_parquet_footer(p, root=tmp_path)
+    assert info.relative_path == "sub/f.parquet"
+    assert info.num_rows == 2
+    assert info.num_row_groups == 2
+    assert info.columns == ("patient_id", "value")
+    assert info.size_bytes > 0
+    assert len(info.schema_signature) == 16
+
+
+def test_scan_inventory_walks_and_dedups(parquet_lake):
+    result = scan_inventory(parquet_lake)
+    assert result.total_files == 4
+    assert result.total_rows == 100 + 50 + 30 + 10
+    # two distinct schemas in EHR/labs (A) vs vitals (B) vs notes (C) = 3 distinct
+    assert result.distinct_schema_count == 3
+    # the two EHR/labs files share schema A -> same signature
+    labs = sorted(f for f in result.files if f.relative_path.startswith("EHR/labs"))
+    assert labs[0].schema_signature == labs[1].schema_signature
+    # duplicate basename "part-0.parquet" across EHR/labs and EHR/vitals
+    dups = result.duplicate_filenames()
+    assert "part-0.parquet" in dups
+    assert sorted(dups["part-0.parquet"]) == ["EHR/labs/part-0.parquet", "EHR/vitals/part-0.parquet"]
+
+
+def test_scan_inventory_records_errors_for_bad_parquet(tmp_path):
+    # a non-parquet file with a .parquet extension should be recorded as an error, not crash
+    bad = tmp_path / "broken.parquet"
+    bad.write_text("not a parquet file")
+    result = scan_inventory(tmp_path)
+    assert result.total_files == 0
+    assert len(result.errors) == 1
+    assert result.errors[0][0] == "broken.parquet"
+
+
+def test_scan_inventory_empty_dir(tmp_path):
+    result = scan_inventory(tmp_path)
+    assert result.total_files == 0
+    assert result.errors == []

--- a/backend/psdl_observatory/tests/test_schema_sig.py
+++ b/backend/psdl_observatory/tests/test_schema_sig.py
@@ -1,0 +1,33 @@
+"""Tests for schema signature -- the stable, order-independent file identity."""
+
+from psdl_observatory.schema_sig import normalize_columns, schema_signature
+
+
+def test_normalize_columns_lowercases_and_strips():
+    assert normalize_columns(["  Patient_ID ", "VALUE"]) == ["patient_id", "value"]
+
+
+def test_signature_is_order_independent():
+    # column order must not change the signature (same schema, reordered)
+    sig_a = schema_signature(["patient_id", "value"], ["int64", "double"])
+    sig_b = schema_signature(["value", "patient_id"], ["double", "int64"])
+    assert sig_a == sig_b
+
+
+def test_signature_changes_with_columns():
+    sig_a = schema_signature(["patient_id", "value"], ["int64", "double"])
+    sig_c = schema_signature(["patient_id"], ["int64"])
+    assert sig_a != sig_c
+
+
+def test_signature_changes_with_types():
+    sig_a = schema_signature(["value"], ["double"])
+    sig_b = schema_signature(["value"], ["string"])
+    assert sig_a != sig_b
+
+
+def test_signature_is_hex_digest():
+    sig = schema_signature(["a"], ["int64"])
+    assert isinstance(sig, str)
+    assert len(sig) == 16  # truncated sha256 hex
+    int(sig, 16)  # parses as hex

--- a/backend/psdl_observatory/tests/test_schema_sig.py
+++ b/backend/psdl_observatory/tests/test_schema_sig.py
@@ -31,3 +31,9 @@ def test_signature_is_hex_digest():
     assert isinstance(sig, str)
     assert len(sig) == 16  # truncated sha256 hex
     int(sig, 16)  # parses as hex
+
+
+def test_signature_raises_on_length_mismatch():
+    import pytest
+    with pytest.raises(ValueError):
+        schema_signature(["a", "b"], ["int64"])

--- a/backend/psdl_observatory/tests/test_synthea_integration.py
+++ b/backend/psdl_observatory/tests/test_synthea_integration.py
@@ -30,6 +30,7 @@ def test_scan_synthea_edw(tmp_path):
     # writers succeed end-to-end on real data
     out = write_all(result, tmp_path / "scans")
     assert out["inventory"].exists()
-    # sharded tables produce duplicate basenames (e.g. patients-0.parquet patterns)
-    # -- at minimum the scan completes and the summary is written
+    # Synthea shards are named "{table}-{i}.parquet" so basenames are unique
+    # across tables (no duplicate filenames expected); we assert the scan
+    # completes cleanly and the summary is written.
     assert out["summary"].read_text().startswith("PSDL Observatory")

--- a/backend/psdl_observatory/tests/test_synthea_integration.py
+++ b/backend/psdl_observatory/tests/test_synthea_integration.py
@@ -1,0 +1,35 @@
+"""Integration test: scan a Synthea-generated parquet EDW.
+
+Skipped unless PSDL_OBSERVATORY_SYNTHEA_EDW points at a parquet lake built by
+scripts/make_synthea_edw.py. Keeps CI hermetic while letting us validate the
+scanner against a realistic, multi-table 'new EDW'.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from psdl_observatory import scan_inventory, write_all
+
+EDW = os.environ.get("PSDL_OBSERVATORY_SYNTHEA_EDW")
+
+pytestmark = pytest.mark.skipif(
+    not EDW or not Path(EDW).is_dir(),
+    reason="set PSDL_OBSERVATORY_SYNTHEA_EDW to a Synthea parquet lake to run",
+)
+
+
+def test_scan_synthea_edw(tmp_path):
+    result = scan_inventory(EDW)
+    # a real synthetic EDW has many parquet files across multiple tables/schemas
+    assert result.total_files > 5
+    assert result.total_rows > 0
+    assert result.distinct_schema_count >= 3  # patients/encounters/observations differ
+    assert result.errors == []
+    # writers succeed end-to-end on real data
+    out = write_all(result, tmp_path / "scans")
+    assert out["inventory"].exists()
+    # sharded tables produce duplicate basenames (e.g. patients-0.parquet patterns)
+    # -- at minimum the scan completes and the summary is written
+    assert out["summary"].read_text().startswith("PSDL Observatory")

--- a/backend/psdl_observatory/tests/test_writers.py
+++ b/backend/psdl_observatory/tests/test_writers.py
@@ -1,0 +1,53 @@
+"""Tests for inventory output writers."""
+
+import csv
+
+from psdl_observatory.models import ParquetFileInfo, ScanResult
+from psdl_observatory.writers import write_all
+
+
+def _sample_result(root):
+    files = [
+        ParquetFileInfo("EHR/labs/part-0.parquet", 100, 100, 2, ("patient_id", "value"), "sigA"),
+        ParquetFileInfo("EHR/labs/part-1.parquet", 80, 50, 1, ("patient_id", "value"), "sigA"),
+        ParquetFileInfo("EHR/vitals/part-0.parquet", 60, 30, 1, ("patient_id", "hr"), "sigB"),
+    ]
+    return ScanResult(root=str(root), files=files, errors=[("bad.parquet", "ArrowInvalid: x")])
+
+
+def test_write_all_creates_three_files(tmp_path):
+    out = write_all(_sample_result(tmp_path), tmp_path / "scans")
+    assert (tmp_path / "scans" / "parquet_inventory.csv").exists()
+    assert (tmp_path / "scans" / "duplicate_filenames.csv").exists()
+    assert (tmp_path / "scans" / "scan_summary.txt").exists()
+    assert set(out.keys()) == {"inventory", "duplicates", "summary"}
+
+
+def test_inventory_csv_has_row_per_file(tmp_path):
+    write_all(_sample_result(tmp_path), tmp_path / "scans")
+    with open(tmp_path / "scans" / "parquet_inventory.csv") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 3
+    assert rows[0]["relative_path"] == "EHR/labs/part-0.parquet"
+    assert rows[0]["num_rows"] == "100"
+    assert rows[0]["schema_signature"] == "sigA"
+    assert rows[0]["columns"] == "patient_id|value"
+
+
+def test_duplicates_csv_lists_shared_basenames(tmp_path):
+    write_all(_sample_result(tmp_path), tmp_path / "scans")
+    with open(tmp_path / "scans" / "duplicate_filenames.csv") as f:
+        rows = list(csv.DictReader(f))
+    # part-0.parquet appears in EHR/labs and EHR/vitals
+    assert len(rows) == 1
+    assert rows[0]["filename"] == "part-0.parquet"
+    assert rows[0]["count"] == "2"
+
+
+def test_summary_txt_reports_totals(tmp_path):
+    write_all(_sample_result(tmp_path), tmp_path / "scans")
+    txt = (tmp_path / "scans" / "scan_summary.txt").read_text()
+    assert "Total files: 3" in txt
+    assert "Total rows: 180" in txt
+    assert "Distinct schemas: 2" in txt
+    assert "Errors: 1" in txt

--- a/backend/psdl_observatory/tests/test_writers.py
+++ b/backend/psdl_observatory/tests/test_writers.py
@@ -51,3 +51,4 @@ def test_summary_txt_reports_totals(tmp_path):
     assert "Total rows: 180" in txt
     assert "Distinct schemas: 2" in txt
     assert "Errors: 1" in txt
+    assert "bad.parquet: ArrowInvalid: x" in txt

--- a/backend/psdl_observatory/writers.py
+++ b/backend/psdl_observatory/writers.py
@@ -1,0 +1,72 @@
+"""Write the inventory scan to CSV/TXT artifacts.
+
+Outputs (per the methodology Stage 01):
+  parquet_inventory.csv   one row per parquet file
+  duplicate_filenames.csv basenames occurring at >1 path
+  scan_summary.txt        human-readable totals
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict, Union
+
+from psdl_observatory.models import ScanResult
+
+
+def write_inventory_csv(result: ScanResult, path: Union[str, Path]) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["relative_path", "filename", "size_bytes", "num_rows",
+                    "num_row_groups", "num_columns", "schema_signature", "columns"])
+        for fi in result.files:
+            w.writerow([fi.relative_path, fi.filename, fi.size_bytes, fi.num_rows,
+                        fi.num_row_groups, fi.num_columns, fi.schema_signature,
+                        "|".join(fi.columns)])
+    return path
+
+
+def write_duplicates_csv(result: ScanResult, path: Union[str, Path]) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["filename", "count", "paths"])
+        for name, paths in sorted(result.duplicate_filenames().items()):
+            w.writerow([name, len(paths), "|".join(paths)])
+    return path
+
+
+def write_summary_txt(result: ScanResult, path: Union[str, Path]) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "PSDL Observatory — Inventory Scan Summary",
+        "=" * 44,
+        f"Root: {result.root}",
+        f"Total files: {result.total_files}",
+        f"Total rows: {result.total_rows}",
+        f"Total size (bytes): {result.total_size_bytes}",
+        f"Distinct schemas: {result.distinct_schema_count}",
+        f"Duplicate filenames: {len(result.duplicate_filenames())}",
+        f"Errors: {len(result.errors)}",
+    ]
+    if result.errors:
+        lines.append("")
+        lines.append("Errors:")
+        for rel, msg in result.errors:
+            lines.append(f"  {rel}: {msg}")
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def write_all(result: ScanResult, out_dir: Union[str, Path]) -> Dict[str, Path]:
+    out_dir = Path(out_dir)
+    return {
+        "inventory": write_inventory_csv(result, out_dir / "parquet_inventory.csv"),
+        "duplicates": write_duplicates_csv(result, out_dir / "duplicate_filenames.csv"),
+        "summary": write_summary_txt(result, out_dir / "scan_summary.txt"),
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,5 @@ meds>=0.3,<0.4
 # (pip install -e ./psdl_vocab_search). ML embedders are optional extras: .[ml]
 # psdl_anchoring is installed editable from ./psdl_anchoring during development
 # (pip install -e ./psdl_anchoring).
+# psdl_observatory is installed editable from ./psdl_observatory during development
+# (pip install -e ./psdl_observatory). EDW inventory scanner (O1).


### PR DESCRIPTION
## Summary
M6 Observatory **O1** — the full Inspector-side inventory scanner. New flat-layout `psdl_observatory` package: scans a parquet lake using **footers only** (never row data, never PHI), emits `parquet_inventory.csv` / `duplicate_filenames.csv` / `scan_summary.txt` + a static HTML report, and a `psdl-observatory scan` CLI.

- File identity = `relative_path + schema_signature` (order-independent), **not filename** — filenames like `deid_notes_cleaned_0.parquet` recur across datasets and aren't globally meaningful.
- Parallel footer reads (`ThreadPoolExecutor`); corrupt files recorded as errors, not fatal.
- Hermetic unit tests (synthetic parquet fixtures) + a Synthea synthetic-EDW integration test (skipped in CI without the dataset).

Workbench will consume these core APIs and add enhanced/customized functions + a `/api/observatory/scan` endpoint — a follow-on, out of scope here.

Spec: `docs/OBSERVATORY_METHODOLOGY.md` Stage 01; `docs/DEVELOPMENT_ROADMAP.md` M6 §O1 (Workbench repo).

## Validation
- `pytest psdl_observatory/` → **24 passed, 1 skipped** (Synthea integration skips without data).
- Editable install imports cleanly from `/tmp` — flat layout, **no namespace-package shadowing**.
- `app.main` boots (25 routes); wider Inspector suite **105 passed, 0 failures**, none referencing the new package.
- **Real-data run**: scanned a live Synthea synthetic EDW → **45 files, 471,836 rows, 14 distinct schemas, 0 errors**.

## Review process
Built in 6 units, each through independent spec + code-quality review. Fixes landed for: a `stat()` TOCTOU, a redundant XSS-risk HTML hack, install-dependent CLI tests, `--workers`/`--out` boundary guards (validated before scanning), and the py3.9 SSL/certifi download bug in the Synthea helper (now works with no curl workaround).

🤖 Generated with [Claude Code](https://claude.com/claude-code)