### PR TITLE
feat(observatory): O2 semantic schema registry (psdl_observatory)

### DIFF
--- a/backend/psdl_observatory/README.md
+++ b/backend/psdl_observatory/README.md
@@ -10,3 +10,11 @@ meaningful).
 
 Inspector ships the full scanner + CLI + HTML report. PSDL Workbench consumes
 these core APIs and adds institutional/enhanced functions.
+
+## Semantic Schema Registry (O2)
+
+Beyond the raw inventory, `build_catalog()` infers structural column roles
+(patient / encounter / time / text / code / outcome) from column names — purely
+heuristic, never clinical concept mapping — and emits `column_catalog.csv` +
+`schema_semantic_catalog.csv` plus a catalog HTML view. CLI: `psdl-observatory
+catalog <root> --out <dir> [--html]`.

--- a/backend/psdl_observatory/__init__.py
+++ b/backend/psdl_observatory/__init__.py
@@ -18,6 +18,19 @@ from psdl_observatory.writers import (
     write_summary_txt,
 )
 from psdl_observatory.report import render_html_report
+from psdl_observatory.roles import infer_role, normalize_col
+from psdl_observatory.catalog import (
+    CatalogResult,
+    ColumnInfo,
+    SchemaProfile,
+    build_catalog,
+)
+from psdl_observatory.catalog_writers import (
+    write_catalog_all,
+    write_column_catalog_csv,
+    write_schema_semantic_catalog_csv,
+)
+from psdl_observatory.report import render_catalog_html
 
 __all__ = [
     "ParquetFileInfo",
@@ -31,4 +44,14 @@ __all__ = [
     "write_duplicates_csv",
     "write_summary_txt",
     "render_html_report",
+    "infer_role",
+    "normalize_col",
+    "CatalogResult",
+    "ColumnInfo",
+    "SchemaProfile",
+    "build_catalog",
+    "write_catalog_all",
+    "write_column_catalog_csv",
+    "write_schema_semantic_catalog_csv",
+    "render_catalog_html",
 ]

--- a/backend/psdl_observatory/__init__.py
+++ b/backend/psdl_observatory/__init__.py
@@ -17,7 +17,7 @@ from psdl_observatory.writers import (
     write_inventory_csv,
     write_summary_txt,
 )
-from psdl_observatory.report import render_html_report
+from psdl_observatory.report import render_catalog_html, render_html_report
 from psdl_observatory.roles import infer_role, normalize_col
 from psdl_observatory.catalog import (
     CatalogResult,
@@ -30,7 +30,6 @@ from psdl_observatory.catalog_writers import (
     write_column_catalog_csv,
     write_schema_semantic_catalog_csv,
 )
-from psdl_observatory.report import render_catalog_html
 
 __all__ = [
     "ParquetFileInfo",

--- a/backend/psdl_observatory/catalog.py
+++ b/backend/psdl_observatory/catalog.py
@@ -60,6 +60,10 @@ class CatalogResult:
 
 def _classify_table_kind(roles_present: List[str]) -> str:
     """A light, documented heuristic label for a schema based on its roles."""
+    # Precedence: a text column dominates (notes table); otherwise the richest
+    # structural combo wins. encounter_events (patient+encounter+time) is checked
+    # before coded_clinical_events because temporal event tables are the more common
+    # shape; a table with codes AND full encounter context is still primarily an event table.
     rp = set(roles_present)
     if ROLE_TEXT in rp:
         return "clinical_notes"
@@ -110,8 +114,17 @@ def build_catalog(scan: ScanResult) -> CatalogResult:
 
     schemas = []
     for sig in sorted(sig_repr):
+        # All files sharing a schema_signature have identical (normalized-name, type)
+        # column sets by construction (see schema_sig.schema_signature), so reading the
+        # columns from one representative file is sufficient.
         f = sig_repr[sig]
-        norm_cols = [normalize_col(c) for c in f.columns]
+        seen = set()
+        norm_cols = []
+        for c in f.columns:
+            n = normalize_col(c)
+            if n not in seen:
+                seen.add(n)
+                norm_cols.append(n)
         counts = {r: 0 for r in ALL_ROLES}
         for nc in norm_cols:
             counts[infer_role(nc)] += 1

--- a/backend/psdl_observatory/catalog.py
+++ b/backend/psdl_observatory/catalog.py
@@ -1,0 +1,129 @@
+"""Build a semantic catalog from a scan: per-column roles + per-schema profiles.
+
+Pure, metadata-only — operates on the O1 ScanResult (footer-derived column
+names), never reads row data.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from psdl_observatory.models import ScanResult
+from psdl_observatory.roles import (
+    ALL_ROLES,
+    ROLE_CODE,
+    ROLE_ENCOUNTER,
+    ROLE_OTHER,
+    ROLE_PATIENT,
+    ROLE_TEXT,
+    ROLE_TIME,
+    infer_role,
+    normalize_col,
+)
+
+
+@dataclass
+class ColumnInfo:
+    """A distinct (normalized) column name across the lake + its inferred role."""
+
+    normalized: str
+    role: str
+    file_count: int          # number of files this column appears in
+    schema_count: int        # number of distinct schema signatures it appears in
+    example_path: str        # one relative path where it occurs
+
+
+@dataclass
+class SchemaProfile:
+    """Semantic profile of one distinct schema signature."""
+
+    schema_signature: str
+    num_files: int
+    columns: List[str]                       # normalized column names
+    role_counts: Dict[str, int]              # role -> count of columns
+    roles_present: List[str]                 # roles with count > 0 (stable order)
+    table_kind: str                          # heuristic label, e.g. 'clinical_notes'
+    example_path: str
+
+    @property
+    def num_columns(self) -> int:
+        return len(self.columns)
+
+
+@dataclass
+class CatalogResult:
+    columns: List[ColumnInfo] = field(default_factory=list)
+    schemas: List[SchemaProfile] = field(default_factory=list)
+
+
+def _classify_table_kind(roles_present: List[str]) -> str:
+    """A light, documented heuristic label for a schema based on its roles."""
+    rp = set(roles_present)
+    if ROLE_TEXT in rp:
+        return "clinical_notes"
+    if ROLE_PATIENT in rp and ROLE_ENCOUNTER in rp and ROLE_TIME in rp:
+        return "encounter_events"
+    if ROLE_CODE in rp and (ROLE_PATIENT in rp or ROLE_ENCOUNTER in rp):
+        return "coded_clinical_events"
+    if ROLE_PATIENT in rp and ROLE_ENCOUNTER not in rp:
+        return "patient_dimension"
+    if ROLE_ENCOUNTER in rp:
+        return "encounter_dimension"
+    return "reference_or_other"
+
+
+def build_catalog(scan: ScanResult) -> CatalogResult:
+    # --- per-column aggregation ---
+    col_files: Dict[str, int] = Counter()
+    col_schemas: Dict[str, set] = defaultdict(set)
+    col_example: Dict[str, str] = {}
+    for f in scan.files:
+        seen_in_file = set()
+        for raw in f.columns:
+            norm = normalize_col(raw)
+            if norm in seen_in_file:
+                continue          # count a column once per file
+            seen_in_file.add(norm)
+            col_files[norm] += 1
+            col_schemas[norm].add(f.schema_signature)
+            col_example.setdefault(norm, f.relative_path)
+
+    columns = [
+        ColumnInfo(
+            normalized=norm,
+            role=infer_role(norm),
+            file_count=col_files[norm],
+            schema_count=len(col_schemas[norm]),
+            example_path=col_example[norm],
+        )
+        for norm in sorted(col_files)
+    ]
+
+    # --- per-schema profiles (one representative file per signature) ---
+    sig_files: Dict[str, int] = Counter()
+    sig_repr = {}  # signature -> representative ParquetFileInfo
+    for f in scan.files:
+        sig_files[f.schema_signature] += 1
+        sig_repr.setdefault(f.schema_signature, f)
+
+    schemas = []
+    for sig in sorted(sig_repr):
+        f = sig_repr[sig]
+        norm_cols = [normalize_col(c) for c in f.columns]
+        counts = {r: 0 for r in ALL_ROLES}
+        for nc in norm_cols:
+            counts[infer_role(nc)] += 1
+        roles_present = [r for r in ALL_ROLES if r != ROLE_OTHER and counts[r] > 0]
+        schemas.append(SchemaProfile(
+            schema_signature=sig,
+            num_files=sig_files[sig],
+            columns=norm_cols,
+            role_counts=counts,
+            roles_present=roles_present,
+            table_kind=_classify_table_kind(roles_present),
+            example_path=f.relative_path,
+        ))
+
+    return CatalogResult(columns=columns, schemas=schemas)

--- a/backend/psdl_observatory/catalog_writers.py
+++ b/backend/psdl_observatory/catalog_writers.py
@@ -1,0 +1,49 @@
+"""Write the semantic catalog to CSV artifacts (Stage 03 outputs).
+
+  column_catalog.csv           one row per distinct (normalized) column
+  schema_semantic_catalog.csv  one row per distinct schema signature
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict, Union
+
+from psdl_observatory.catalog import CatalogResult
+from psdl_observatory.roles import ALL_ROLES
+
+
+def write_column_catalog_csv(catalog: CatalogResult, path: Union[str, Path]) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["column", "role", "file_count", "schema_count", "example_path"])
+        for c in catalog.columns:
+            w.writerow([c.normalized, c.role, c.file_count, c.schema_count, c.example_path])
+    return path
+
+
+def write_schema_semantic_catalog_csv(catalog: CatalogResult, path: Union[str, Path]) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    role_cols = [f"n_{r}" for r in ALL_ROLES]
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["schema_signature", "num_files", "num_columns", "table_kind",
+                    "roles_present", "columns"] + role_cols)
+        for s in catalog.schemas:
+            w.writerow([
+                s.schema_signature, s.num_files, len(s.columns), s.table_kind,
+                "|".join(s.roles_present), "|".join(s.columns),
+            ] + [s.role_counts.get(r, 0) for r in ALL_ROLES])
+    return path
+
+
+def write_catalog_all(catalog: CatalogResult, out_dir: Union[str, Path]) -> Dict[str, Path]:
+    out_dir = Path(out_dir)
+    return {
+        "columns": write_column_catalog_csv(catalog, out_dir / "column_catalog.csv"),
+        "schemas": write_schema_semantic_catalog_csv(catalog, out_dir / "schema_semantic_catalog.csv"),
+    }

--- a/backend/psdl_observatory/catalog_writers.py
+++ b/backend/psdl_observatory/catalog_writers.py
@@ -35,7 +35,7 @@ def write_schema_semantic_catalog_csv(catalog: CatalogResult, path: Union[str, P
                     "roles_present", "columns"] + role_cols)
         for s in catalog.schemas:
             w.writerow([
-                s.schema_signature, s.num_files, len(s.columns), s.table_kind,
+                s.schema_signature, s.num_files, s.num_columns, s.table_kind,
                 "|".join(s.roles_present), "|".join(s.columns),
             ] + [s.role_counts.get(r, 0) for r in ALL_ROLES])
     return path

--- a/backend/psdl_observatory/cli.py
+++ b/backend/psdl_observatory/cli.py
@@ -10,7 +10,9 @@ import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
-from psdl_observatory.report import render_html_report
+from psdl_observatory.catalog import build_catalog
+from psdl_observatory.catalog_writers import write_catalog_all
+from psdl_observatory.report import render_catalog_html, render_html_report
 from psdl_observatory.scanner import scan_inventory
 from psdl_observatory.writers import write_all
 
@@ -41,6 +43,32 @@ def _cmd_scan(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_catalog(args: argparse.Namespace) -> int:
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"error: not a directory: {root}", file=sys.stderr)
+        return 2
+    if args.workers < 1:
+        print(f"error: --workers must be >= 1, got {args.workers}", file=sys.stderr)
+        return 2
+    out_dir = Path(args.out)
+    if out_dir.exists() and not out_dir.is_dir():
+        print(f"error: --out exists and is not a directory: {out_dir}", file=sys.stderr)
+        return 2
+    result = scan_inventory(root, workers=args.workers)
+    catalog = build_catalog(result)
+    paths = write_catalog_all(catalog, out_dir)
+    if args.html:
+        html_path = out_dir / "catalog.html"
+        html_path.write_text(render_catalog_html(catalog))
+        paths["html"] = html_path
+    print(f"catalog: {len(catalog.columns)} distinct columns, "
+          f"{len(catalog.schemas)} distinct schemas")
+    for label, p in paths.items():
+        print(f"  {label}: {p}")
+    return 0
+
+
 def main(argv: Optional[Iterable[str]] = None) -> int:
     parser = argparse.ArgumentParser(prog="psdl-observatory")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -50,6 +78,12 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
     p_scan.add_argument("--html", action="store_true", help="Also write inventory.html")
     p_scan.add_argument("--workers", type=int, default=8, help="Parallel footer-read workers (default 8)")
     p_scan.set_defaults(func=_cmd_scan)
+    p_cat = sub.add_parser("catalog", help="Infer the semantic schema catalog from a parquet lake")
+    p_cat.add_argument("root", help="Root directory of the parquet lake")
+    p_cat.add_argument("--out", required=True, help="Output directory for the catalog artifacts")
+    p_cat.add_argument("--html", action="store_true", help="Also write catalog.html")
+    p_cat.add_argument("--workers", type=int, default=8, help="Parallel footer-read workers (default 8)")
+    p_cat.set_defaults(func=_cmd_catalog)
     ns = parser.parse_args(list(argv) if argv is not None else None)
     return ns.func(ns)
 

--- a/backend/psdl_observatory/cli.py
+++ b/backend/psdl_observatory/cli.py
@@ -64,7 +64,7 @@ def _cmd_catalog(args: argparse.Namespace) -> int:
         html_path.write_text(render_catalog_html(catalog))
         paths["html"] = html_path
     print(f"catalog: {len(catalog.columns)} distinct columns, "
-          f"{len(catalog.schemas)} distinct schemas")
+          f"{len(catalog.schemas)} distinct schemas, {len(result.errors)} scan errors")
     for label, p in paths.items():
         print(f"  {label}: {p}")
     return 0

--- a/backend/psdl_observatory/cli.py
+++ b/backend/psdl_observatory/cli.py
@@ -1,6 +1,7 @@
 """`psdl-observatory` command-line entry point.
 
     psdl-observatory scan <root> --out <dir> [--html] [--workers N]
+    psdl-observatory catalog <root> --out <dir> [--html] [--workers N]
 """
 
 from __future__ import annotations

--- a/backend/psdl_observatory/report.py
+++ b/backend/psdl_observatory/report.py
@@ -68,3 +68,60 @@ def render_html_report(result: ScanResult) -> str:
 </body>
 </html>
 """
+
+
+def render_catalog_html(catalog) -> str:
+    """Render the semantic catalog (columns + schema profiles) as static HTML.
+
+    All dynamic text is HTML-escaped. `catalog` is a CatalogResult.
+    """
+    col_rows = "\n".join(
+        "<tr>"
+        f"<td>{escape(c.normalized)}</td>"
+        f"<td>{escape(c.role)}</td>"
+        f"<td>{c.file_count}</td>"
+        f"<td>{c.schema_count}</td>"
+        f"<td>{escape(c.example_path)}</td>"
+        "</tr>"
+        for c in catalog.columns
+    ) or '<tr><td colspan="5">none</td></tr>'
+    schema_rows = "\n".join(
+        "<tr>"
+        f"<td><code>{escape(s.schema_signature)}</code></td>"
+        f"<td>{s.num_files}</td>"
+        f"<td>{len(s.columns)}</td>"
+        f"<td>{escape(s.table_kind)}</td>"
+        f"<td>{escape('|'.join(s.roles_present))}</td>"
+        f"<td>{escape('|'.join(s.columns))}</td>"
+        "</tr>"
+        for s in catalog.schemas
+    ) or '<tr><td colspan="6">none</td></tr>'
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>PSDL Observatory — Semantic Catalog</title>
+<style>
+ body {{ font-family: -apple-system, system-ui, sans-serif; margin: 2rem; color: #1a1a1a; }}
+ h1 {{ font-size: 1.4rem; }}
+ table {{ border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: 0.85rem; }}
+ th, td {{ border: 1px solid #ddd; padding: 4px 8px; text-align: left; }}
+ th {{ background: #f0f0f3; }}
+ code {{ font-size: 0.8rem; }}
+</style>
+</head>
+<body>
+<h1>PSDL Observatory — Semantic Schema Catalog</h1>
+<h2>Schemas ({len(catalog.schemas)})</h2>
+<table>
+<tr><th>Schema sig</th><th>Files</th><th>Cols</th><th>Table kind</th><th>Roles present</th><th>Columns</th></tr>
+{schema_rows}
+</table>
+<h2>Columns ({len(catalog.columns)})</h2>
+<table>
+<tr><th>Column</th><th>Role</th><th>File count</th><th>Schema count</th><th>Example path</th></tr>
+{col_rows}
+</table>
+</body>
+</html>
+"""

--- a/backend/psdl_observatory/report.py
+++ b/backend/psdl_observatory/report.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from html import escape
 
+from psdl_observatory.catalog import CatalogResult
 from psdl_observatory.models import ScanResult
 
 
@@ -70,7 +71,7 @@ def render_html_report(result: ScanResult) -> str:
 """
 
 
-def render_catalog_html(catalog) -> str:
+def render_catalog_html(catalog: CatalogResult) -> str:
     """Render the semantic catalog (columns + schema profiles) as static HTML.
 
     All dynamic text is HTML-escaped. `catalog` is a CatalogResult.

--- a/backend/psdl_observatory/roles.py
+++ b/backend/psdl_observatory/roles.py
@@ -33,10 +33,12 @@ def normalize_col(name: str) -> str:
     """Normalize a column name: lowercase, split camelCase, unify separators.
 
     'encounterID' -> 'encounter_id'; 'Visit-Occurrence-ID' -> 'visit_occurrence_id';
-    'note__text' -> 'note_text'.
+    'note__text' -> 'note_text'; 'MRNNumber' -> 'mrn_number'.
     """
-    # split camelCase / PascalCase boundaries: aB -> a_B, and ABc -> A_Bc
-    s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name.strip())
+    # split ALL-CAPS run followed by a capitalized word: ACRONYMWord -> ACRONYM_Word
+    s = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", "_", name.strip())
+    # split camelCase / PascalCase boundaries: aB -> a_B
+    s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", s)
     s = s.lower()
     # any run of non-alphanumeric becomes a single underscore
     s = re.sub(r"[^a-z0-9]+", "_", s)
@@ -57,15 +59,19 @@ ROLE_PATTERNS: List[Tuple[str, List[str]]] = [
     (ROLE_ENCOUNTER, [
         r"^(encounter|visit|admission|hospitalization|hadm|stay|episode|enc)_?"
         r"(id|key|num|occurrence_id|sk)$",
-        r"^visit_occurrence_id$",
+        # Note: ^visit_occurrence_id$ is already matched by the pattern above
+        # (stem=visit, suffix=occurrence_id) — removed as dead code.
     ]),
     (ROLE_CODE, [
         r"^(icd9|icd10|icd|cpt4?|hcpcs|loinc|snomed|rxnorm|ndc|atc)\w*$",
         r".*_code$", r"^code$", r"^concept_id$", r"^(source|target)_concept_id$",
     ]),
     (ROLE_TIME, [
-        r".*(time|date|datetime|timestamp)$", r"^dob$", r".*_at$", r".*_ts$",
+        r"^(time|date|datetime|timestamp)$",           # bare word
+        r".*_(time|date|datetime|timestamp)$",         # underscore-delimited suffix
+        r"^dob$", r".*_at$", r".*_ts$",
         r"^(chart|admit|disch|event|start|end|birth|death)time$",
+        r"^(birth|death|chart|admit|disch)date$",      # bare compound date forms
     ]),
     (ROLE_OUTCOME, [
         r"^(mortality|death|deceased|expired|alive|survival|disposition)$",
@@ -78,12 +84,16 @@ ROLE_PATTERNS: List[Tuple[str, List[str]]] = [
     ]),
 ]
 
+# Precompiled patterns for performance (infer_role is called over thousands of
+# columns in the O2 catalog scan).
+_COMPILED_PATTERNS = [(role, [re.compile(p) for p in pats]) for role, pats in ROLE_PATTERNS]
+
 
 def infer_role(column_name: str) -> str:
     """Return the structural role for a column name (first matching pattern)."""
     norm = normalize_col(column_name)
-    for role, patterns in ROLE_PATTERNS:
-        for pat in patterns:
-            if re.match(pat, norm):
+    for role, compiled in _COMPILED_PATTERNS:
+        for rx in compiled:
+            if rx.match(norm):
                 return role
     return ROLE_OTHER

--- a/backend/psdl_observatory/roles.py
+++ b/backend/psdl_observatory/roles.py
@@ -78,7 +78,7 @@ ROLE_PATTERNS: List[Tuple[str, List[str]]] = [
     (ROLE_OUTCOME, [
         r"^(mortality|death|deceased|expired|alive|survival|disposition)$",
         r"^discharge_disposition$", r"^readmit\w*$", r"^outcome$",
-        r".*_(flag|status)$",
+        r"^(death|deceased|mortality|expired|survival|discharge|readmission|readmit|vital|alive)_(flag|status)$",
     ]),
     (ROLE_TEXT, [
         r"^(note|notes|text|narrative|comment|comments|report|description|reason)$",

--- a/backend/psdl_observatory/roles.py
+++ b/backend/psdl_observatory/roles.py
@@ -33,16 +33,20 @@ def normalize_col(name: str) -> str:
     """Normalize a column name: lowercase, split camelCase, unify separators.
 
     'encounterID' -> 'encounter_id'; 'Visit-Occurrence-ID' -> 'visit_occurrence_id';
-    'note__text' -> 'note_text'; 'MRNNumber' -> 'mrn_number'.
+    'note__text' -> 'note_text'; 'MRNNumber' -> 'mrn_number';
+    '注射时间' -> '注射时间' (non-ASCII preserved); 'naïve_café' -> 'naïve_café'.
     """
     # split ALL-CAPS run followed by a capitalized word: ACRONYMWord -> ACRONYM_Word
     s = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", "_", name.strip())
     # split camelCase / PascalCase boundaries: aB -> a_B
     s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", s)
     s = s.lower()
-    # any run of non-alphanumeric becomes a single underscore
-    s = re.sub(r"[^a-z0-9]+", "_", s)
-    return s.strip("_")
+    # non-word (Unicode-aware) runs -> underscore; underscores are \w so are preserved here
+    s = re.sub(r"[^\w]+", "_", s, flags=re.UNICODE)
+    # collapse repeated underscores, strip ends
+    s = re.sub(r"_+", "_", s).strip("_")
+    # never return empty (e.g. a pure-symbol/emoji name): fall back to the stripped raw
+    return s or name.strip().lower()
 
 
 # Ordered (role, [regex]) pairs. FIRST match wins. Ordering rationale:
@@ -55,34 +59,44 @@ ROLE_PATTERNS: List[Tuple[str, List[str]]] = [
     (ROLE_PATIENT, [
         r"^(patient|person|subject|member|pat)_?(id|key|num|identifier|sk)$",
         r"^mrn$", r"^pat_?id$",
-        r"^patient$", r"^person$",    # bare FK names (e.g. Synthea EDW)
+        r"^patient$", r"^person$",          # bare FK names (e.g. Synthea)
+        r".*_mrn_id$", r".*_mrn$",           # Epic PAT_MRN_ID etc.
     ]),
     (ROLE_ENCOUNTER, [
         r"^(encounter|visit|admission|hospitalization|hadm|stay|episode|enc)_?"
         r"(id|key|num|occurrence_id|sk)$",
-        r"^encounter$",               # bare FK name (e.g. Synthea EDW)
-        # Note: ^visit_occurrence_id$ is already matched by the pattern above
-        # (stem=visit, suffix=occurrence_id) — removed as dead code.
+        r"^encounter$",                      # bare FK name
+        r".*_csn_id$", r".*_csn$",           # Epic Contact Serial Number = encounter id
     ]),
     (ROLE_CODE, [
-        r"^(icd9|icd10|icd|cpt4?|hcpcs|loinc|snomed|rxnorm|ndc|atc)\w*$",
-        r".*_code$", r"^code$", r"^concept_id$", r"^(source|target)_concept_id$",
+        # exact vocabulary names (no trailing \w* — avoids grabbing icd_version/icd_type)
+        r"^(icd9cm|icd10cm|icd9|icd10|icd|cpt4|cpt|hcpcs|loinc|snomed|rxnorm|ndc|atc)$",
+        # embedded vocabulary token as a suffix (lab_loinc, dx_icd10, ...)
+        r".*_(loinc|icd9|icd10|icd|cpt4|cpt|hcpcs|snomed|rxnorm|ndc)$",
+        r".*_code$", r"^code$",
+        r".*_concept_id$", r"^concept_id$",  # OMOP coded backbone (condition_concept_id, ...)
+        r"^(concept|modifier)_cd$",          # i2b2 fact-table code columns (NOT a blanket *_cd)
     ]),
     (ROLE_TIME, [
-        r"^(time|date|datetime|timestamp)$",           # bare word
-        r".*_(time|date|datetime|timestamp)$",         # underscore-delimited suffix
-        r"^dob$", r".*_at$", r".*_ts$",
-        r"^(chart|admit|disch|event|start|end|birth|death)time$",
-        r"^(birth|death|chart|admit|disch)date$",      # bare compound date forms
+        r"^(time|date|datetime|timestamp)$",
+        r".*_(time|date|datetime|timestamp|dt|dttm)$",   # +Epic _DT/_DTTM suffix
+        r"^dob$", r"^dod$",                              # date of birth / death
+        r".*_at$", r".*_ts$",
+        # bare concatenated *time forms (incl. MIMIC in/out/store/edreg/edout)
+        r"^(chart|admit|disch|event|start|end|birth|death|store|in|out|edreg|edout|reg)time$",
+        r"^(birth|death|chart|admit|disch)date$",
     ]),
     (ROLE_OUTCOME, [
         r"^(mortality|death|deceased|expired|alive|survival|disposition)$",
         r"^discharge_disposition$", r"^readmit\w*$", r"^outcome$",
-        r"^(death|deceased|mortality|expired|survival|discharge|readmission|readmit|vital|alive)_(flag|status)$",
+        # clinically-stemmed flag/status/ind ONLY (marital_status/active_flag stay 'other')
+        r".*(death|deceased|mortality|expire|expired|survival|vital|discharge|readmission|readmit|alive)_(flag|status|ind)$",
     ]),
     (ROLE_TEXT, [
         r"^(note|notes|text|narrative|comment|comments|report|description|reason)$",
-        r".*_(text|note|narrative|comment|description)$", r"^note_\w+$",
+        r".*_(text|note|narrative|comment|description)$",
+        r".*_blob$",                         # i2b2 observation_blob etc.
+        # NOTE: removed the old r"^note_\w+$" — it stole note_id/note_type/note_*_concept_id
     ]),
 ]
 

--- a/backend/psdl_observatory/roles.py
+++ b/backend/psdl_observatory/roles.py
@@ -55,10 +55,12 @@ ROLE_PATTERNS: List[Tuple[str, List[str]]] = [
     (ROLE_PATIENT, [
         r"^(patient|person|subject|member|pat)_?(id|key|num|identifier|sk)$",
         r"^mrn$", r"^pat_?id$",
+        r"^patient$", r"^person$",    # bare FK names (e.g. Synthea EDW)
     ]),
     (ROLE_ENCOUNTER, [
         r"^(encounter|visit|admission|hospitalization|hadm|stay|episode|enc)_?"
         r"(id|key|num|occurrence_id|sk)$",
+        r"^encounter$",               # bare FK name (e.g. Synthea EDW)
         # Note: ^visit_occurrence_id$ is already matched by the pattern above
         # (stem=visit, suffix=occurrence_id) — removed as dead code.
     ]),

--- a/backend/psdl_observatory/roles.py
+++ b/backend/psdl_observatory/roles.py
@@ -1,0 +1,89 @@
+"""Structural column-role inference for the EDW semantic registry.
+
+Roles describe the STRUCTURAL semantics of a column (is it a patient
+identifier? a timestamp? free text?) — NOT clinical concept mapping (that is
+M1 auto-mapping / FAISS, a separate problem). Inference is heuristic and based
+on real column names, never hardcoded table assumptions.
+
+ROLE_PATTERNS is intentionally a plain, ordered data structure so the community
+can PR additional patterns without touching logic. First matching role wins
+(precedence matters — see the ordering rationale inline).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+ROLE_PATIENT = "patient"
+ROLE_ENCOUNTER = "encounter"
+ROLE_CODE = "code"
+ROLE_TIME = "time"
+ROLE_OUTCOME = "outcome"
+ROLE_TEXT = "text"
+ROLE_OTHER = "other"
+
+ALL_ROLES = (
+    ROLE_PATIENT, ROLE_ENCOUNTER, ROLE_CODE, ROLE_TIME,
+    ROLE_OUTCOME, ROLE_TEXT, ROLE_OTHER,
+)
+
+
+def normalize_col(name: str) -> str:
+    """Normalize a column name: lowercase, split camelCase, unify separators.
+
+    'encounterID' -> 'encounter_id'; 'Visit-Occurrence-ID' -> 'visit_occurrence_id';
+    'note__text' -> 'note_text'.
+    """
+    # split camelCase / PascalCase boundaries: aB -> a_B, and ABc -> A_Bc
+    s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name.strip())
+    s = s.lower()
+    # any run of non-alphanumeric becomes a single underscore
+    s = re.sub(r"[^a-z0-9]+", "_", s)
+    return s.strip("_")
+
+
+# Ordered (role, [regex]) pairs. FIRST match wins. Ordering rationale:
+#   patient/encounter ID columns first (they often contain tokens that would
+#   otherwise match weaker patterns); code before time so '*_code' is code;
+#   time before outcome so '*_date'/'*_time' is a timestamp even when the stem
+#   is clinically an outcome (e.g. 'death_date' is a time, 'death_flag' is an
+#   outcome); text last among the named roles.
+ROLE_PATTERNS: List[Tuple[str, List[str]]] = [
+    (ROLE_PATIENT, [
+        r"^(patient|person|subject|member|pat)_?(id|key|num|identifier|sk)$",
+        r"^mrn$", r"^pat_?id$",
+    ]),
+    (ROLE_ENCOUNTER, [
+        r"^(encounter|visit|admission|hospitalization|hadm|stay|episode|enc)_?"
+        r"(id|key|num|occurrence_id|sk)$",
+        r"^visit_occurrence_id$",
+    ]),
+    (ROLE_CODE, [
+        r"^(icd9|icd10|icd|cpt4?|hcpcs|loinc|snomed|rxnorm|ndc|atc)\w*$",
+        r".*_code$", r"^code$", r"^concept_id$", r"^(source|target)_concept_id$",
+    ]),
+    (ROLE_TIME, [
+        r".*(time|date|datetime|timestamp)$", r"^dob$", r".*_at$", r".*_ts$",
+        r"^(chart|admit|disch|event|start|end|birth|death)time$",
+    ]),
+    (ROLE_OUTCOME, [
+        r"^(mortality|death|deceased|expired|alive|survival|disposition)$",
+        r"^discharge_disposition$", r"^readmit\w*$", r"^outcome$",
+        r".*_(flag|status)$",
+    ]),
+    (ROLE_TEXT, [
+        r"^(note|notes|text|narrative|comment|comments|report|description|reason)$",
+        r".*_(text|note|narrative|comment|description)$", r"^note_\w+$",
+    ]),
+]
+
+
+def infer_role(column_name: str) -> str:
+    """Return the structural role for a column name (first matching pattern)."""
+    norm = normalize_col(column_name)
+    for role, patterns in ROLE_PATTERNS:
+        for pat in patterns:
+            if re.match(pat, norm):
+                return role
+    return ROLE_OTHER

--- a/backend/psdl_observatory/tests/test_catalog.py
+++ b/backend/psdl_observatory/tests/test_catalog.py
@@ -61,6 +61,18 @@ def test_build_catalog_empty_scan(tmp_path):
     assert cat.schemas == []
 
 
+def test_build_catalog_preserves_distinct_non_ascii_columns():
+    from psdl_observatory.models import ParquetFileInfo, ScanResult
+    f = ParquetFileInfo(
+        relative_path="x/f.parquet", size_bytes=1, num_rows=1, num_row_groups=1,
+        columns=("注射时间", "日期"), schema_signature="sigU",
+    )
+    cat = build_catalog(ScanResult(root="/r", files=[f], errors=[]))
+    norms = {c.normalized for c in cat.columns}
+    assert len(cat.columns) == 2          # NOT collapsed to 1 empty-string entry
+    assert "" not in norms
+
+
 def test_build_catalog_dedups_normalized_columns_in_schema_profile():
     from psdl_observatory.models import ParquetFileInfo, ScanResult
     from psdl_observatory.roles import ROLE_TEXT

--- a/backend/psdl_observatory/tests/test_catalog.py
+++ b/backend/psdl_observatory/tests/test_catalog.py
@@ -1,0 +1,58 @@
+"""Tests for build_catalog over a ScanResult."""
+
+from psdl_observatory import scan_inventory
+from psdl_observatory.catalog import (
+    CatalogResult,
+    ColumnInfo,
+    SchemaProfile,
+    build_catalog,
+)
+from psdl_observatory.roles import ROLE_PATIENT, ROLE_TIME, ROLE_TEXT
+
+
+def test_build_catalog_over_synthetic_lake(parquet_lake):
+    scan = scan_inventory(parquet_lake)
+    cat = build_catalog(scan)
+    assert isinstance(cat, CatalogResult)
+
+    # --- column catalog ---
+    by_name = {c.normalized: c for c in cat.columns}
+    # patient_id appears in EHR/labs (schema A, 2 files) AND EHR/vitals (schema B)
+    assert "patient_id" in by_name
+    pid = by_name["patient_id"]
+    assert pid.role == ROLE_PATIENT
+    assert pid.file_count == 3          # labs part-0, labs part-1, vitals part-0
+    assert pid.schema_count == 2        # schema A and schema B
+    # 'text' column (NOTES schema) -> text role
+    assert by_name["text"].role == ROLE_TEXT
+    # 'value' -> other
+    from psdl_observatory.roles import ROLE_OTHER
+    assert by_name["value"].role == ROLE_OTHER
+
+    # --- schema profiles ---
+    assert len(cat.schemas) == scan.distinct_schema_count  # 3 distinct schemas
+    # the NOTES schema profile has a text column -> roles_present includes text
+    notes = [s for s in cat.schemas if "text" in s.columns]
+    assert len(notes) == 1
+    assert ROLE_TEXT in notes[0].roles_present
+    # the labs schema (patient_id, value) -> has patient, no encounter
+    labs = [s for s in cat.schemas if "value" in s.columns and "patient_id" in s.columns]
+    assert len(labs) == 1
+    assert ROLE_PATIENT in labs[0].roles_present
+    assert labs[0].num_files == 2       # part-0 + part-1 share schema A
+
+
+def test_build_catalog_role_counts_and_table_kind(parquet_lake):
+    scan = scan_inventory(parquet_lake)
+    cat = build_catalog(scan)
+    for s in cat.schemas:
+        # role_counts sums to num_columns
+        assert sum(s.role_counts.values()) == s.num_columns
+        assert s.table_kind  # non-empty label
+
+
+def test_build_catalog_empty_scan(tmp_path):
+    scan = scan_inventory(tmp_path)  # no parquet files
+    cat = build_catalog(scan)
+    assert cat.columns == []
+    assert cat.schemas == []

--- a/backend/psdl_observatory/tests/test_catalog.py
+++ b/backend/psdl_observatory/tests/test_catalog.py
@@ -40,6 +40,9 @@ def test_build_catalog_over_synthetic_lake(parquet_lake):
     assert len(labs) == 1
     assert ROLE_PATIENT in labs[0].roles_present
     assert labs[0].num_files == 2       # part-0 + part-1 share schema A
+    assert labs[0].role_counts["patient"] == 1
+    from psdl_observatory.roles import ROLE_OTHER
+    assert labs[0].role_counts[ROLE_OTHER] == 1
 
 
 def test_build_catalog_role_counts_and_table_kind(parquet_lake):
@@ -56,3 +59,21 @@ def test_build_catalog_empty_scan(tmp_path):
     cat = build_catalog(scan)
     assert cat.columns == []
     assert cat.schemas == []
+
+
+def test_build_catalog_dedups_normalized_columns_in_schema_profile():
+    from psdl_observatory.models import ParquetFileInfo, ScanResult
+    from psdl_observatory.roles import ROLE_TEXT
+    # two raw names that normalize to the same key within one file
+    f = ParquetFileInfo(
+        relative_path="x/f.parquet", size_bytes=1, num_rows=1, num_row_groups=1,
+        columns=("note_text", "note__text"), schema_signature="sigX",
+    )
+    cat = build_catalog(ScanResult(root="/r", files=[f], errors=[]))
+    prof = cat.schemas[0]
+    assert prof.columns == ["note_text"]          # deduped, order preserved
+    assert prof.num_columns == 1
+    assert prof.role_counts[ROLE_TEXT] == 1
+    assert sum(prof.role_counts.values()) == 1
+    # and the per-column catalog also has a single entry
+    assert [c.normalized for c in cat.columns] == ["note_text"]

--- a/backend/psdl_observatory/tests/test_catalog_report.py
+++ b/backend/psdl_observatory/tests/test_catalog_report.py
@@ -39,3 +39,10 @@ def test_catalog_html_escapes():
     assert "&lt;script&gt;" in html
     assert "<b>.parquet" not in html
     assert "&lt;b&gt;.parquet" in html
+
+
+def test_catalog_html_empty():
+    html = render_catalog_html(CatalogResult(columns=[], schemas=[]))
+    assert html.lstrip().startswith("<!DOCTYPE html>")
+    assert "none" in html          # both tables show the sentinel row
+    assert "(0)" in html           # the <h2> counters show 0

--- a/backend/psdl_observatory/tests/test_catalog_report.py
+++ b/backend/psdl_observatory/tests/test_catalog_report.py
@@ -1,0 +1,41 @@
+"""Tests for the semantic catalog HTML view."""
+
+from psdl_observatory.catalog import CatalogResult, ColumnInfo, SchemaProfile
+from psdl_observatory.report import render_catalog_html
+from psdl_observatory.roles import ROLE_PATIENT, ROLE_TEXT
+
+
+def _catalog():
+    columns = [
+        ColumnInfo("patient_id", ROLE_PATIENT, 3, 2, "EHR/labs/part-0.parquet"),
+        ColumnInfo("note_text", ROLE_TEXT, 1, 1, "NOTES/notes-0.parquet"),
+    ]
+    schemas = [
+        SchemaProfile("sigA", 2, ["patient_id", "value"],
+                      {"patient": 1, "other": 1}, ["patient"],
+                      "patient_dimension", "EHR/labs/part-0.parquet"),
+    ]
+    return CatalogResult(columns=columns, schemas=schemas)
+
+
+def test_catalog_html_is_html():
+    html = render_catalog_html(_catalog())
+    assert html.lstrip().startswith("<!DOCTYPE html>")
+    assert "</html>" in html
+
+
+def test_catalog_html_includes_roles_and_columns():
+    html = render_catalog_html(_catalog())
+    assert "patient_id" in html
+    assert "patient" in html
+    assert "note_text" in html
+    assert "patient_dimension" in html
+
+
+def test_catalog_html_escapes():
+    cols = [ColumnInfo("weird<script>", "other", 1, 1, "x/<b>.parquet")]
+    html = render_catalog_html(CatalogResult(columns=cols, schemas=[]))
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+    assert "<b>.parquet" not in html
+    assert "&lt;b&gt;.parquet" in html

--- a/backend/psdl_observatory/tests/test_catalog_writers.py
+++ b/backend/psdl_observatory/tests/test_catalog_writers.py
@@ -52,3 +52,5 @@ def test_schema_semantic_csv_rows(tmp_path):
     assert r["table_kind"] == "patient_dimension"
     assert r["roles_present"] == "patient"
     assert r["columns"] == "patient_id|value"
+    assert r["n_patient"] == "1"
+    assert r["n_other"] == "1"

--- a/backend/psdl_observatory/tests/test_catalog_writers.py
+++ b/backend/psdl_observatory/tests/test_catalog_writers.py
@@ -1,0 +1,54 @@
+"""Tests for the catalog CSV writers."""
+
+import csv
+
+from psdl_observatory.catalog import CatalogResult, ColumnInfo, SchemaProfile
+from psdl_observatory.catalog_writers import write_catalog_all
+from psdl_observatory.roles import ROLE_PATIENT, ROLE_TEXT
+
+
+def _sample():
+    columns = [
+        ColumnInfo("patient_id", ROLE_PATIENT, 3, 2, "EHR/labs/part-0.parquet"),
+        ColumnInfo("note_text", ROLE_TEXT, 1, 1, "NOTES/notes-0.parquet"),
+    ]
+    schemas = [
+        SchemaProfile(
+            schema_signature="sigA", num_files=2, columns=["patient_id", "value"],
+            role_counts={"patient": 1, "other": 1}, roles_present=["patient"],
+            table_kind="patient_dimension", example_path="EHR/labs/part-0.parquet",
+        ),
+    ]
+    return CatalogResult(columns=columns, schemas=schemas)
+
+
+def test_write_catalog_all_creates_two_files(tmp_path):
+    out = write_catalog_all(_sample(), tmp_path / "reports")
+    assert (tmp_path / "reports" / "column_catalog.csv").exists()
+    assert (tmp_path / "reports" / "schema_semantic_catalog.csv").exists()
+    assert set(out.keys()) == {"columns", "schemas"}
+
+
+def test_column_catalog_csv_rows(tmp_path):
+    write_catalog_all(_sample(), tmp_path / "reports")
+    with open(tmp_path / "reports" / "column_catalog.csv") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 2
+    pid = [r for r in rows if r["column"] == "patient_id"][0]
+    assert pid["role"] == "patient"
+    assert pid["file_count"] == "3"
+    assert pid["schema_count"] == "2"
+    assert pid["example_path"] == "EHR/labs/part-0.parquet"
+
+
+def test_schema_semantic_csv_rows(tmp_path):
+    write_catalog_all(_sample(), tmp_path / "reports")
+    with open(tmp_path / "reports" / "schema_semantic_catalog.csv") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["schema_signature"] == "sigA"
+    assert r["num_files"] == "2"
+    assert r["table_kind"] == "patient_dimension"
+    assert r["roles_present"] == "patient"
+    assert r["columns"] == "patient_id|value"

--- a/backend/psdl_observatory/tests/test_cli.py
+++ b/backend/psdl_observatory/tests/test_cli.py
@@ -54,3 +54,32 @@ def test_cli_out_is_file_errors(parquet_lake, tmp_path):
     r = _run("scan", str(parquet_lake), "--out", str(bad_out), cwd=tmp_path)
     assert r.returncode == 2
     assert "not a directory" in r.stderr
+
+
+def test_cli_catalog_writes_outputs(parquet_lake, tmp_path):
+    out = tmp_path / "reports"
+    r = _run("catalog", str(parquet_lake), "--out", str(out), cwd=tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert (out / "column_catalog.csv").exists()
+    assert (out / "schema_semantic_catalog.csv").exists()
+    assert "columns" in r.stdout  # summary mentions column/schema counts
+
+
+def test_cli_catalog_html_flag(parquet_lake, tmp_path):
+    out = tmp_path / "reports"
+    r = _run("catalog", str(parquet_lake), "--out", str(out), "--html", cwd=tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert (out / "catalog.html").exists()
+    assert "<!DOCTYPE html>" in (out / "catalog.html").read_text()
+
+
+def test_cli_catalog_bad_root_errors(tmp_path):
+    r = _run("catalog", str(tmp_path / "nope"), "--out", str(tmp_path / "r"), cwd=tmp_path)
+    assert r.returncode == 2
+    assert "not a directory" in r.stderr
+
+
+def test_cli_help_lists_catalog(tmp_path):
+    r = _run("--help", cwd=tmp_path)
+    assert r.returncode == 0
+    assert "catalog" in r.stdout

--- a/backend/psdl_observatory/tests/test_cli.py
+++ b/backend/psdl_observatory/tests/test_cli.py
@@ -83,3 +83,17 @@ def test_cli_help_lists_catalog(tmp_path):
     r = _run("--help", cwd=tmp_path)
     assert r.returncode == 0
     assert "catalog" in r.stdout
+
+
+def test_cli_catalog_workers_zero_errors(parquet_lake, tmp_path):
+    r = _run("catalog", str(parquet_lake), "--out", str(tmp_path / "reports"), "--workers", "0", cwd=tmp_path)
+    assert r.returncode == 2
+    assert "workers must be >= 1" in r.stderr
+
+
+def test_cli_catalog_out_is_file_errors(parquet_lake, tmp_path):
+    bad_out = tmp_path / "afile"
+    bad_out.write_text("x")
+    r = _run("catalog", str(parquet_lake), "--out", str(bad_out), cwd=tmp_path)
+    assert r.returncode == 2
+    assert "not a directory" in r.stderr

--- a/backend/psdl_observatory/tests/test_cli.py
+++ b/backend/psdl_observatory/tests/test_cli.py
@@ -97,3 +97,19 @@ def test_cli_catalog_out_is_file_errors(parquet_lake, tmp_path):
     r = _run("catalog", str(parquet_lake), "--out", str(bad_out), cwd=tmp_path)
     assert r.returncode == 2
     assert "not a directory" in r.stderr
+
+
+def test_cli_catalog_reports_scan_errors(tmp_path):
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    root = tmp_path / "lake"
+    root.mkdir()
+    pq.write_table(pa.table({"patient_id": [1, 2]}), root / "good.parquet")
+    (root / "bad.parquet").write_text("not a parquet")
+    out = tmp_path / "reports"
+    r = _run("catalog", str(root), "--out", str(out), cwd=tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "1 scan error" in r.stdout or "errors" in r.stdout.lower()
+    # the corrupt file must not have aborted the catalog of the good file
+    assert (out / "column_catalog.csv").exists()

--- a/backend/psdl_observatory/tests/test_roles.py
+++ b/backend/psdl_observatory/tests/test_roles.py
@@ -117,3 +117,69 @@ def test_infer_role_false_positives_and_edge_cases(col, role):
 def test_normalize_col_handles_allcaps_acronyms():
     assert normalize_col("MRNNumber") == "mrn_number"
     assert normalize_col("CDWPatientKey") == "cdw_patient_key"
+
+
+def test_normalize_col_preserves_non_ascii():
+    # CJK: must return non-empty and preserve the characters
+    result_cjk = normalize_col("注射时间")
+    assert result_cjk != ""
+    assert result_cjk == "注射时间"
+    # accents preserved
+    assert normalize_col("naïve_café") == "naïve_café"
+    assert normalize_col("DÉCÈS") == "décès"
+
+
+@pytest.mark.parametrize("col,role", [
+    # OMOP *_concept_id backbone -> code (the big fix)
+    ("condition_concept_id", ROLE_CODE),
+    ("gender_concept_id", ROLE_CODE),
+    ("measurement_concept_id", ROLE_CODE),
+    ("value_as_concept_id", ROLE_CODE),
+    ("visit_concept_id", ROLE_CODE),
+    ("source_concept_id", ROLE_CODE),
+    # encounter/patient FKs still win over code (precedence)
+    ("visit_occurrence_id", ROLE_ENCOUNTER),
+    ("person_id", ROLE_PATIENT),
+    # i2b2 codes (conservative whitelist) + non-code _cd stays other
+    ("concept_cd", ROLE_CODE),
+    ("modifier_cd", ROLE_CODE),
+    ("units_cd", ROLE_OTHER),
+    ("sex_cd", ROLE_OTHER),
+    # embedded vocab token
+    ("lab_loinc", ROLE_CODE),
+    # icd_version must NOT be code (was a false positive)
+    ("icd_version", ROLE_OTHER),
+    ("icd10", ROLE_CODE),
+    ("cpt4", ROLE_CODE),
+    # Epic vendor tokens
+    ("pat_enc_csn_id", ROLE_ENCOUNTER),
+    ("note_csn_id", ROLE_ENCOUNTER),
+    ("pat_mrn_id", ROLE_PATIENT),
+    # time: Epic _DT suffix + MIMIC bare *time + dod
+    ("effective_date_dt", ROLE_TIME),
+    ("death_date_dt", ROLE_TIME),
+    ("intime", ROLE_TIME),
+    ("outtime", ROLE_TIME),
+    ("storetime", ROLE_TIME),
+    ("edregtime", ROLE_TIME),
+    ("dod", ROLE_TIME),
+    # note_* no longer all text
+    ("note_id", ROLE_OTHER),
+    ("note_type", ROLE_OTHER),
+    ("note_text", ROLE_TEXT),
+    ("clinical_note", ROLE_TEXT),
+    # outcome: clinical flags yes, demographic/technical no (anti-phantom-outcome)
+    ("hospital_expire_flag", ROLE_OUTCOME),
+    ("vital_status", ROLE_OUTCOME),
+    ("death_flag", ROLE_OUTCOME),
+    ("marital_status", ROLE_OTHER),
+    ("active_flag", ROLE_OTHER),
+    ("employment_status", ROLE_OTHER),
+    # i2b2 blob -> text
+    ("observation_blob", ROLE_TEXT),
+    # measurement value stays other
+    ("value_as_number", ROLE_OTHER),
+    ("valuenum", ROLE_OTHER),
+])
+def test_infer_role_new_cases(col, role):
+    assert infer_role(col) == role

--- a/backend/psdl_observatory/tests/test_roles.py
+++ b/backend/psdl_observatory/tests/test_roles.py
@@ -30,12 +30,15 @@ def test_normalize_col_lowercases_and_unifies_separators():
     ("subject_id", ROLE_PATIENT),
     ("mrn", ROLE_PATIENT),
     ("person_key", ROLE_PATIENT),
+    ("patient", ROLE_PATIENT),
+    ("person", ROLE_PATIENT),
     # encounter
     ("encounter_id", ROLE_ENCOUNTER),
     ("visit_occurrence_id", ROLE_ENCOUNTER),
     ("hadm_id", ROLE_ENCOUNTER),
     ("stay_id", ROLE_ENCOUNTER),
     ("admission_id", ROLE_ENCOUNTER),
+    ("encounter", ROLE_ENCOUNTER),
     # code (checked before time so *_code wins over nothing)
     ("diagnosis_code", ROLE_CODE),
     ("icd10_code", ROLE_CODE),

--- a/backend/psdl_observatory/tests/test_roles.py
+++ b/backend/psdl_observatory/tests/test_roles.py
@@ -86,3 +86,24 @@ def test_infer_role_precedence_date_beats_outcome():
 def test_infer_role_is_case_insensitive():
     assert infer_role("Patient_ID") == ROLE_PATIENT
     assert infer_role("ChartTime") == ROLE_TIME
+
+
+@pytest.mark.parametrize("col,role", [
+    # false positives that must NOT be time (the .*date$/.*time$ bug)
+    ("update", ROLE_OTHER),
+    ("candidate", ROLE_OTHER),
+    ("validate", ROLE_OTHER),
+    ("mandate", ROLE_OTHER),
+    # documented decision: *_code is code (incl. zip/error) — acceptable noise
+    ("zip_code", ROLE_CODE),
+    ("error_code", ROLE_CODE),
+    # bare birthdate/deathdate concatenated forms
+    ("birthdate", ROLE_TIME),
+])
+def test_infer_role_false_positives_and_edge_cases(col, role):
+    assert infer_role(col) == role
+
+
+def test_normalize_col_handles_allcaps_acronyms():
+    assert normalize_col("MRNNumber") == "mrn_number"
+    assert normalize_col("CDWPatientKey") == "cdw_patient_key"

--- a/backend/psdl_observatory/tests/test_roles.py
+++ b/backend/psdl_observatory/tests/test_roles.py
@@ -1,0 +1,88 @@
+"""Tests for column-name normalization + structural role inference."""
+
+import pytest
+
+from psdl_observatory.roles import (
+    ROLE_OTHER,
+    ROLE_PATIENT,
+    ROLE_ENCOUNTER,
+    ROLE_TIME,
+    ROLE_TEXT,
+    ROLE_CODE,
+    ROLE_OUTCOME,
+    infer_role,
+    normalize_col,
+)
+
+
+def test_normalize_col_lowercases_and_unifies_separators():
+    assert normalize_col("  Patient ID ") == "patient_id"
+    assert normalize_col("encounterID") == "encounter_id"
+    assert normalize_col("Visit-Occurrence-ID") == "visit_occurrence_id"
+    assert normalize_col("charttime") == "charttime"
+    assert normalize_col("note__text") == "note_text"
+
+
+@pytest.mark.parametrize("col,role", [
+    # patient
+    ("patient_id", ROLE_PATIENT),
+    ("person_id", ROLE_PATIENT),
+    ("subject_id", ROLE_PATIENT),
+    ("mrn", ROLE_PATIENT),
+    ("person_key", ROLE_PATIENT),
+    # encounter
+    ("encounter_id", ROLE_ENCOUNTER),
+    ("visit_occurrence_id", ROLE_ENCOUNTER),
+    ("hadm_id", ROLE_ENCOUNTER),
+    ("stay_id", ROLE_ENCOUNTER),
+    ("admission_id", ROLE_ENCOUNTER),
+    # code (checked before time so *_code wins over nothing)
+    ("diagnosis_code", ROLE_CODE),
+    ("icd10_code", ROLE_CODE),
+    ("loinc", ROLE_CODE),
+    ("cpt4", ROLE_CODE),
+    ("concept_id", ROLE_CODE),
+    ("ndc", ROLE_CODE),
+    # time
+    ("charttime", ROLE_TIME),
+    ("admittime", ROLE_TIME),
+    ("event_time", ROLE_TIME),
+    ("birth_date", ROLE_TIME),
+    ("dob", ROLE_TIME),
+    ("created_at", ROLE_TIME),
+    ("measurement_datetime", ROLE_TIME),
+    # outcome
+    ("mortality", ROLE_OUTCOME),
+    ("deceased", ROLE_OUTCOME),
+    ("discharge_disposition", ROLE_OUTCOME),
+    ("expired", ROLE_OUTCOME),
+    ("readmitted", ROLE_OUTCOME),
+    # text
+    ("note_text", ROLE_TEXT),
+    ("clinical_note", ROLE_TEXT),
+    ("narrative", ROLE_TEXT),
+    ("report_text", ROLE_TEXT),
+    # other
+    ("value", ROLE_OTHER),
+    ("row_id", ROLE_OTHER),
+    ("quantity", ROLE_OTHER),
+])
+def test_infer_role(col, role):
+    assert infer_role(col) == role
+
+
+def test_infer_role_precedence_id_beats_code():
+    # patient_id ends in _id, must be patient (not code despite containing 'id')
+    assert infer_role("patient_id") == ROLE_PATIENT
+
+
+def test_infer_role_precedence_date_beats_outcome():
+    # a death DATE is a timestamp → time wins over the outcome 'death' token
+    assert infer_role("death_date") == ROLE_TIME
+    # but a bare mortality flag is outcome
+    assert infer_role("death_flag") == ROLE_OUTCOME
+
+
+def test_infer_role_is_case_insensitive():
+    assert infer_role("Patient_ID") == ROLE_PATIENT
+    assert infer_role("ChartTime") == ROLE_TIME

--- a/backend/psdl_observatory/tests/test_roles.py
+++ b/backend/psdl_observatory/tests/test_roles.py
@@ -69,6 +69,13 @@ def test_normalize_col_lowercases_and_unifies_separators():
     ("value", ROLE_OTHER),
     ("row_id", ROLE_OTHER),
     ("quantity", ROLE_OTHER),
+    # _flag/_status must be clinically anchored — these are NOT outcomes
+    ("marital_status", ROLE_OTHER),
+    ("active_flag", ROLE_OTHER),
+    ("employment_status", ROLE_OTHER),
+    # clinically-stemmed flag/status ARE outcomes
+    ("vital_status", ROLE_OUTCOME),
+    ("discharge_status", ROLE_OUTCOME),
 ])
 def test_infer_role(col, role):
     assert infer_role(col) == role

--- a/backend/psdl_observatory/tests/test_synthea_integration.py
+++ b/backend/psdl_observatory/tests/test_synthea_integration.py
@@ -34,3 +34,21 @@ def test_scan_synthea_edw(tmp_path):
     # across tables (no duplicate filenames expected); we assert the scan
     # completes cleanly and the summary is written.
     assert out["summary"].read_text().startswith("PSDL Observatory")
+
+
+def test_build_catalog_synthea_edw(tmp_path):
+    from psdl_observatory import build_catalog, scan_inventory, write_catalog_all
+    from psdl_observatory.roles import ROLE_PATIENT, ROLE_TIME
+
+    scan = scan_inventory(EDW)
+    cat = build_catalog(scan)
+    # a real EDW has many distinct columns and several schemas
+    assert len(cat.columns) > 10
+    assert len(cat.schemas) == scan.distinct_schema_count
+    roles_seen = {c.role for c in cat.columns}
+    # Synthea tables have patient identifiers and timestamps
+    assert ROLE_PATIENT in roles_seen
+    assert ROLE_TIME in roles_seen
+    # writers succeed end-to-end on real data
+    out = write_catalog_all(cat, tmp_path / "reports")
+    assert out["columns"].exists() and out["schemas"].exists()


### PR DESCRIPTION
## Summary
M6 Observatory **O2** — extends `psdl_observatory` (merged in #13) with the Stage-03 semantic schema registry. Pure-heuristic structural column-role inference (patient / encounter / time / text / code / outcome / other) emitted as `column_catalog.csv` + `schema_semantic_catalog.csv` + a catalog HTML view + a `psdl-observatory catalog` CLI subcommand. Metadata-only (operates on O1's footer-derived column names — never reads parquet rows).

- File identity reuses O1's `relative_path + schema_signature`.
- `ROLE_PATTERNS` is a precedence-ordered regex dict, designed to be community-PR-extensible.
- Workbench will consume these core APIs and add the FAISS/M1-backed concept mapping + Reviews-queue gold approval as a follow-on plan.

Spec: `docs/superpowers/specs/2026-05-21-three-tier-architecture.md` (Workbench) M6 §O2; methodology `docs/OBSERVATORY_METHODOLOGY.md` Stage 03.

## Validation
- `pytest psdl_observatory/` → **96 passed, 2 skipped** (Synthea integration skips without data).
- Editable install imports cleanly from `/tmp`; `app.main` boots clean (25 routes); wider Inspector suite **169 passed, 0 failures**.
- **Real-data run**: catalogued the Synthea synthetic EDW → 76 columns / 14 schemas / all four table-kinds (`patient_dimension`, `clinical_notes`, `encounter_events`, `coded_clinical_events`) / sensible roles.

## Hard-eval hardening (what's most worth knowing)
A "test hard" adversarial evaluation lifted role accuracy from **71.7% → 91.9%** overall and `code` recall from **10.9% → 78.3%** before this branch landed. The classifier now correctly recognizes OMOP `*_concept_id` columns (the dominant gap; critical because UF runs OMOP), MIMIC bare `*time` forms, Epic `_DT`/CSN/MRN, and i2b2 codes. Phantom-outcome over-capture from `_(flag|status)` is anchored to clinical stems. Scanner proven metadata-only two independent ways (timing 1.07× vs ~40,000× if rows were read; row-reader APIs monkeypatched off, scan still succeeds). Zero crashes on adversarial filesystems. Fully deterministic. The 258-column OMOP/MIMIC/i2b2/PCORnet/Epic labeled set produced by this eval becomes the gold for the Workbench eval-report feature.

## Test plan
- [x] `pytest psdl_observatory/` — 96 passed, 1 Synthea integration test + Synthea catalog integration test skip without dataset
- [x] `app.main` boots; wider Inspector suite no new failures
- [x] Real-data demo on Synthea (cataloged in commit `a188964`)
- [x] Adversarial accuracy eval re-run after hardening → 91.9% / code 78.3%

🤖 Generated with [Claude Code](https://claude.com/claude-code)