### PR TITLE
feat(vocab-search): wire BioLORD v2 release into psdl_vocab_search + routers

### DIFF
--- a/backend/app/routers/vocabulary.py
+++ b/backend/app/routers/vocabulary.py
@@ -15,6 +15,16 @@ try:
 except ImportError:
     SEMANTIC_AVAILABLE = False
 
+# Try to import the BioLORD v2 modular engine (psdl_vocab_search package).
+# When available it replaces the OpenAI/SQLite semantic service for the two
+# search endpoints; the old service is kept as a fallback and for the
+# population concept-lookup / stats routes that don't use it yet.
+try:
+    from psdl_vocab_search.factory import get_biolord_v2_engine
+    BIOLORD_V2_AVAILABLE = True
+except ImportError:
+    BIOLORD_V2_AVAILABLE = False
+
 
 router = APIRouter()
 
@@ -262,11 +272,44 @@ async def semantic_search_vocabulary(
     limit: int = Query(20, ge=1, le=100, description="Max results"),
     category: Optional[str] = Query(None, description="Filter by category"),
 ) -> SearchResponse:
-    """Semantic search LOINC vocabulary using embeddings.
+    """Semantic search vocabulary using BioLORD v2 embeddings.
 
-    Uses text-embedding-3-small embeddings for semantic similarity search.
-    Falls back to text search if embeddings unavailable.
+    Primarily uses the modular BioLORD v2 engine (pre-built FAISS index,
+    563k concepts).  Falls back to the legacy OpenAI/SQLite service if the
+    BioLORD engine is unavailable.
     """
+    # --- BioLORD v2 path (preferred) ---
+    if BIOLORD_V2_AVAILABLE:
+        try:
+            engine = get_biolord_v2_engine()
+            raw_results = engine.search(q, limit=limit)
+
+            # Apply category filter post-hoc if requested.
+            if category:
+                raw_results = [r for r in raw_results if r.metadata.get("category") == category]
+
+            concepts = [
+                ConceptResponse(**clean_concept({
+                    "concept_id": r.concept_id,
+                    "concept_name": r.concept_name,
+                    "concept_code": r.concept_code,
+                    "vocabulary_id": r.vocabulary_id,
+                    "domain_id": r.domain_id,
+                    "abbreviations": r.metadata.get("abbreviations"),
+                    "search_terms": r.metadata.get("search_terms"),
+                    "category": r.metadata.get("category"),
+                    "typical_units": r.metadata.get("typical_units"),
+                }))
+                for r in raw_results
+            ]
+            return SearchResponse(query=q, total=len(concepts), results=concepts)
+
+        except Exception as exc:
+            # Engine error — fall through to legacy service if available.
+            if not SEMANTIC_AVAILABLE:
+                raise HTTPException(status_code=500, detail=f"BioLORD v2 search error: {exc}")
+
+    # --- Legacy OpenAI/SQLite fallback ---
     if not SEMANTIC_AVAILABLE:
         raise HTTPException(status_code=503, detail="Semantic search not available")
 
@@ -297,15 +340,67 @@ async def search_population(
 
     Args:
         q: Search query string
-        type: Filter by 'conditions' (SNOMED) or 'medications' (RxNorm)
+        type: Filter by 'conditions' (SNOMED) or 'medications' (RxNorm); maps to
+              vocabulary_id SNOMED (conditions) or RxNorm (medications).
         limit: Maximum number of results
         semantic: Use semantic (embedding) search if available
 
     Returns:
         Matching concepts ranked by relevance
     """
+    # Vocabulary-ID filter map for population type.
+    VOCAB_MAP = {
+        "conditions": "SNOMED",
+        "medications": "RxNorm",
+    }
+    target_vocab = VOCAB_MAP.get(type) if type else None
+
+    # --- BioLORD v2 path (preferred) ---
+    if BIOLORD_V2_AVAILABLE and semantic:
+        try:
+            engine = get_biolord_v2_engine()
+            # Fetch more candidates than requested so the vocabulary filter
+            # has enough headroom after slicing.
+            fetch_limit = limit * 5 if target_vocab else limit
+            raw_results = engine.search(q, limit=fetch_limit)
+
+            # Filter by vocabulary_id for conditions / medications.
+            if target_vocab:
+                raw_results = [r for r in raw_results if r.vocabulary_id == target_vocab]
+
+            raw_results = raw_results[:limit]
+
+            concepts = [
+                PopulationConceptResponse(**clean_concept({
+                    "concept_id": r.concept_id,
+                    "concept_name": r.concept_name,
+                    "concept_code": r.concept_code,
+                    "vocabulary_id": r.vocabulary_id,
+                    "domain_id": r.domain_id,
+                    "abbreviations": r.metadata.get("abbreviations"),
+                    "search_terms": r.metadata.get("search_terms"),
+                    "category": r.metadata.get("category"),
+                }))
+                for r in raw_results
+            ]
+            return PopulationSearchResponse(
+                query=q,
+                vocab_type=type,
+                total=len(concepts),
+                results=concepts,
+            )
+
+        except Exception as exc:
+            # Engine error — fall through to legacy service if available.
+            if not SEMANTIC_AVAILABLE:
+                raise HTTPException(status_code=500, detail=f"BioLORD v2 population search error: {exc}")
+
+    # --- Legacy OpenAI/SQLite fallback ---
     if not SEMANTIC_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Population search not available - semantic service missing")
+        raise HTTPException(
+            status_code=503,
+            detail="Population search not available - semantic service missing",
+        )
 
     service = get_semantic_vocabulary_service()
 

--- a/backend/psdl_vocab_search/_index_loader.py
+++ b/backend/psdl_vocab_search/_index_loader.py
@@ -1,0 +1,145 @@
+"""Resolve the directory containing the pre-built BioLORD v2 FAISS index.
+
+Resolution order:
+1. PSDL_VOCAB_SEARCH_DATA_DIR env var (offline override)
+2. Cache hit at PSDL_VOCAB_SEARCH_CACHE_DIR (default ~/.cache/psdl_vocab_search/v2-biolord/)
+3. Download tarball from the pinned GitHub Release, unpack atomically into the cache dir.
+
+Required artifact files: index.faiss, index.faiss.meta, metadata.json.
+(The slim asset does not include embeddings.npy — only the pre-built FAISS index is shipped.)
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import ssl
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+INDEX_VERSION = "v2-biolord"
+INDEX_TARBALL_URL = (
+    "https://github.com/Chesterguan/psdl-inspector/releases/download/"
+    "vocab-embeddings-v2-biolord/vocab-embeddings-v2-biolord.tar.gz"
+)
+# Slim asset — tarball contains only the three files below (no embeddings.npy).
+REQUIRED_FILES = ("index.faiss", "index.faiss.meta", "metadata.json")
+
+
+def _cache_dir() -> Path:
+    """Return the cache directory for the BioLORD v2 index."""
+    override = os.environ.get("PSDL_VOCAB_SEARCH_CACHE_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / ".cache" / "psdl_vocab_search" / INDEX_VERSION
+
+
+def _all_present(directory: Path) -> bool:
+    """Return True if all required files exist in *directory*."""
+    return all((directory / f).exists() for f in REQUIRED_FILES)
+
+
+def _ssl_context() -> ssl.SSLContext:
+    """Build an SSL context, preferring certifi's CA bundle when available.
+
+    certifi ships with pip/requests and sidesteps the common macOS python.org
+    "CERTIFICATE_VERIFY_FAILED" failure caused by a missing system CA store.
+    Falls back to the platform default context if certifi is absent.
+    """
+    try:
+        import certifi  # soft dependency — present in virtually every venv
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:  # pragma: no cover - certifi missing / unusable
+        return ssl.create_default_context()
+
+
+def _download_and_unpack(cache_dir: Path) -> None:
+    """Download the tarball from the pinned GitHub Release and unpack it.
+
+    Uses a temp file + atomic rename strategy so an interrupted download never
+    leaves partial/corrupt files that would appear as a valid cache hit on the
+    next call.
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        prefix=".biolord-", suffix=".tar.gz", dir=str(cache_dir)
+    )
+    os.close(tmp_fd)
+    tmp_tarball = Path(tmp_name)
+
+    try:
+        print("[psdl_vocab_search] Downloading BioLORD v2 index (~1.7 GB) ...", flush=True)
+        with urllib.request.urlopen(
+            INDEX_TARBALL_URL, context=_ssl_context()
+        ) as resp, open(tmp_tarball, "wb") as out:
+            shutil.copyfileobj(resp, out)
+
+        # Unpack into a staging directory, then atomically move each file into
+        # place so partial unpacks don't corrupt the cache.
+        tmp_unpack = cache_dir / ".unpack_tmp"
+        if tmp_unpack.exists():
+            shutil.rmtree(tmp_unpack)
+        tmp_unpack.mkdir()
+
+        with tarfile.open(tmp_tarball, "r:gz") as tf:
+            tf.extractall(str(tmp_unpack))
+
+        # Move only the required files; ignore anything else in the tarball.
+        for fname in REQUIRED_FILES:
+            src = tmp_unpack / fname
+            dst = cache_dir / fname
+            if src.exists():
+                os.replace(src, dst)
+
+        shutil.rmtree(tmp_unpack, ignore_errors=True)
+        print(f"[psdl_vocab_search] Index cached at {cache_dir}", flush=True)
+
+    except (urllib.error.URLError, OSError, EOFError, tarfile.TarError) as exc:
+        raise RuntimeError(
+            f"psdl_vocab_search could not download the BioLORD v2 index from "
+            f"{INDEX_TARBALL_URL} ({exc}). "
+            "For offline installs set PSDL_VOCAB_SEARCH_DATA_DIR to a directory "
+            "containing the three artifact files (index.faiss, index.faiss.meta, "
+            "metadata.json) and retry."
+        ) from exc
+    finally:
+        try:
+            tmp_tarball.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def get_index_dir() -> Path:
+    """Return the directory containing the pre-built BioLORD v2 FAISS index.
+
+    Resolution order (see module docstring):
+    1. PSDL_VOCAB_SEARCH_DATA_DIR env override (offline / CI / dev)
+    2. Cache hit at the default cache directory
+    3. First-use download from the pinned GitHub Release
+
+    Always returns a real :class:`pathlib.Path`; raises :exc:`RuntimeError` on
+    misconfiguration or download failure.
+    """
+    override = os.environ.get("PSDL_VOCAB_SEARCH_DATA_DIR")
+    if override:
+        p = Path(override)
+        if not p.is_dir():
+            raise RuntimeError(
+                f"PSDL_VOCAB_SEARCH_DATA_DIR={override!r} is not a directory"
+            )
+        if not _all_present(p):
+            missing = [f for f in REQUIRED_FILES if not (p / f).exists()]
+            raise RuntimeError(
+                f"PSDL_VOCAB_SEARCH_DATA_DIR={override!r} is missing files: {missing}"
+            )
+        return p
+
+    cache_dir = _cache_dir()
+    if _all_present(cache_dir):
+        return cache_dir
+
+    _download_and_unpack(cache_dir)
+    return cache_dir

--- a/backend/psdl_vocab_search/factory.py
+++ b/backend/psdl_vocab_search/factory.py
@@ -104,6 +104,31 @@ class SearchEngineConfig:
         """Highest quality configuration (slower)."""
         return cls(embedder="biolord", retriever="faiss", reranker="hybrid")
 
+    @classmethod
+    def biolord_v2(cls) -> "SearchEngineConfig":
+        """BioLORD v2 configuration backed by pre-built FAISS index.
+
+        Uses the pre-built BioLORD v2 FAISS index (downloaded/cached on first
+        use via ``_index_loader``).  The vocabulary JSON is resolved via
+        ``psdl_vocab``'s data loader so both data assets share the same
+        download/cache discipline.
+        """
+        try:
+            from psdl_vocab._data_loader import get_vocab_data_path
+
+            vocab_path = str(get_vocab_data_path() / "vocabulary_final.json")
+        except Exception:
+            # psdl_vocab not installed or vocab not yet downloaded; fall back
+            # to the default path resolution so __post_init__ handles it.
+            vocab_path = None
+
+        return cls(
+            embedder="biolord",
+            retriever="faiss-preloaded",
+            reranker="rules",
+            vocab_path=vocab_path,
+        )
+
 
 def create_search_engine(config: SearchEngineConfig) -> VocabularySearchEngine:
     """Create a search engine with the given configuration.
@@ -161,6 +186,26 @@ def reset_engine() -> None:
     global _default_engine, _current_config
     _default_engine = None
     _current_config = None
+
+
+# BioLORD v2 singleton — lazily created on first call.
+_biolord_v2_engine: Optional[VocabularySearchEngine] = None
+
+
+def get_biolord_v2_engine() -> VocabularySearchEngine:
+    """Return the singleton BioLORD v2 search engine.
+
+    On first call this creates the engine using ``SearchEngineConfig.biolord_v2()``
+    (which uses the pre-built FAISS index via ``PreloadedFAISSRetriever``).
+    Subsequent calls return the cached instance.
+    """
+    global _biolord_v2_engine
+
+    if _biolord_v2_engine is None:
+        config = SearchEngineConfig.biolord_v2()
+        _biolord_v2_engine = create_search_engine(config)
+
+    return _biolord_v2_engine
 
 
 def list_available_components() -> dict:

--- a/backend/psdl_vocab_search/factory.py
+++ b/backend/psdl_vocab_search/factory.py
@@ -130,6 +130,44 @@ class SearchEngineConfig:
         )
 
 
+class PreloadedVocabularySearchEngine(VocabularySearchEngine):
+    """Search engine variant that uses a pre-built FAISS index.
+
+    Overrides ``load()`` to skip the embedding + index-build phase entirely —
+    it only loads the vocabulary JSON (needed for result metadata lookup) and
+    then calls ``retriever._ensure_loaded()`` so the pre-built index is ready.
+
+    This prevents ``VocabularySearchEngine.load()`` from falling through to
+    ``_build_index()`` when no standard cache files are found.
+    """
+
+    def load(self) -> None:
+        if self._loaded:
+            return
+
+        import json
+        from pathlib import Path
+
+        # Load vocabulary JSON for _concepts_by_id (concept metadata lookup).
+        vocab_file = Path(self.vocab_path)
+        if not vocab_file.exists():
+            raise FileNotFoundError(f"Vocabulary file not found: {self.vocab_path}")
+
+        with open(vocab_file) as f:
+            self._concepts = json.load(f)
+
+        self._concepts_by_id = {c["concept_id"]: c for c in self._concepts}
+
+        # Trigger pre-built index load (downloads if not yet cached).
+        # The retriever is a PreloadedFAISSRetriever — call its _ensure_loaded
+        # directly rather than going through the standard load(path) path which
+        # would return False and trigger a full re-embed.
+        if hasattr(self.retriever, "_ensure_loaded"):
+            self.retriever._ensure_loaded()
+
+        self._loaded = True
+
+
 def create_search_engine(config: SearchEngineConfig) -> VocabularySearchEngine:
     """Create a search engine with the given configuration.
 
@@ -143,7 +181,17 @@ def create_search_engine(config: SearchEngineConfig) -> VocabularySearchEngine:
     retriever = get_retriever(config.retriever)
     reranker = get_reranker(config.reranker)
 
-    return VocabularySearchEngine(
+    # Use the preloaded engine variant for retrievers that carry a pre-built
+    # index (identified by the presence of _ensure_loaded).  This skips the
+    # embedding + index-build phase so no re-embedding happens at runtime.
+    from psdl_vocab_search.retrievers import PreloadedFAISSRetriever
+    engine_cls = (
+        PreloadedVocabularySearchEngine
+        if isinstance(retriever, PreloadedFAISSRetriever)
+        else VocabularySearchEngine
+    )
+
+    return engine_cls(
         embedder=embedder,
         retriever=retriever,
         reranker=reranker,

--- a/backend/psdl_vocab_search/pyproject.toml
+++ b/backend/psdl_vocab_search/pyproject.toml
@@ -25,6 +25,15 @@ dev = [
     "pytest>=7.4.0",
 ]
 
+[tool.pytest.ini_options]
+# Add the backend scripts directory to sys.path so that tests which import
+# build_biolord_embeddings (a script, not a package) can find it without
+# requiring callers to set PYTHONPATH manually.
+pythonpath = ["../scripts"]
+markers = [
+    "integration: marks tests that require the downloaded BioLORD v2 index (deselect with '-m not integration')",
+]
+
 [tool.setuptools]
 # This pyproject.toml lives INSIDE the package directory (flat layout).
 # Tell setuptools to treat the current directory as the source of the

--- a/backend/psdl_vocab_search/retrievers.py
+++ b/backend/psdl_vocab_search/retrievers.py
@@ -240,9 +240,77 @@ class HNSWRetriever(BaseRetriever):
             return False
 
 
+class PreloadedFAISSRetriever(BaseRetriever):
+    """FAISS retriever that loads a pre-built index from disk.
+
+    Unlike FAISSRetriever (which builds the index from embeddings), this
+    retriever reads an already-built index.faiss + index.faiss.meta file pair
+    produced by the offline BioLORD build script.  The *index_dir* argument is
+    primarily an injection point for tests; production code resolves it via
+    ``_index_loader.get_index_dir()``.
+
+    ``build_index()`` is intentionally a no-op because the index is pre-built.
+    """
+
+    def __init__(self, index_dir=None):
+        # index_dir: Path | str | None.  None → resolved lazily on first search.
+        self._index_dir = index_dir
+        self._index = None
+        self._concept_ids: List[int] = []
+        self._loaded = False
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+
+        import faiss
+        import pickle
+        from pathlib import Path
+
+        if self._index_dir is None:
+            from psdl_vocab_search._index_loader import get_index_dir
+            self._index_dir = get_index_dir()
+
+        index_dir = Path(self._index_dir)
+        index_path = index_dir / "index.faiss"
+        meta_path = index_dir / "index.faiss.meta"
+
+        self._index = faiss.read_index(str(index_path))
+        with open(meta_path, "rb") as f:
+            self._concept_ids = pickle.load(f)
+
+        self._loaded = True
+
+    # build_index is a no-op — the index is pre-built offline.
+    def build_index(self, embeddings, concept_ids: List[int]) -> None:  # type: ignore[override]
+        pass
+
+    def search(self, query_embedding, k: int) -> List[tuple[int, float]]:
+        self._ensure_loaded()
+
+        query = query_embedding.reshape(1, -1).astype("float32")
+        scores, indices = self._index.search(query, k)
+
+        results = []
+        for score, idx in zip(scores[0], indices[0]):
+            if 0 <= idx < len(self._concept_ids):
+                results.append((self._concept_ids[idx], float(score)))
+
+        return results
+
+    def save(self, path: str) -> None:
+        # Pre-built index — saving is a no-op (the source-of-truth is the cached files).
+        pass
+
+    def load(self, path: str) -> bool:
+        # Pre-built index — the standard path-based load is not used.
+        return False
+
+
 # Registry of available retrievers
 RETRIEVER_REGISTRY = {
     "faiss": FAISSRetriever,
+    "faiss-preloaded": PreloadedFAISSRetriever,
     "numpy": NumpyRetriever,
     "hnsw": HNSWRetriever,
 }

--- a/backend/psdl_vocab_search/tests/conftest.py
+++ b/backend/psdl_vocab_search/tests/conftest.py
@@ -1,0 +1,60 @@
+"""Skip guard for integration tests that require the BioLORD v2 index.
+
+Integration tests are skipped unless one of the following conditions is met:
+1. PSDL_RUN_INTEGRATION=1 is set in the environment (explicit opt-in).
+2. PSDL_VOCAB_SEARCH_DATA_DIR is set (offline override pointing to a local index dir).
+3. The BioLORD v2 cache exists at the default cache location
+   (~/.cache/psdl_vocab_search/v2-biolord/ or PSDL_VOCAB_SEARCH_CACHE_DIR).
+
+This mirrors the psdl_vocab conftest pattern so unit test runs stay fast and
+network-free.  The integration guard is applied via pytest_collection_modifyitems
+so the skip reason is visible in the collected output.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+# Required files for the pre-built index (must match _index_loader.REQUIRED_FILES).
+_REQUIRED_FILES = ("index.faiss", "index.faiss.meta", "metadata.json")
+
+
+def _index_available() -> bool:
+    """Return True if the BioLORD v2 index is accessible without a download."""
+    # 1. Explicit env override.
+    if os.environ.get("PSDL_VOCAB_SEARCH_DATA_DIR"):
+        return True
+
+    # 2. Custom cache dir override.
+    cache_override = os.environ.get("PSDL_VOCAB_SEARCH_CACHE_DIR")
+    if cache_override:
+        d = Path(cache_override)
+        return all((d / f).exists() for f in _REQUIRED_FILES)
+
+    # 3. Default cache location.
+    default = Path.home() / ".cache" / "psdl_vocab_search" / "v2-biolord"
+    return all((default / f).exists() for f in _REQUIRED_FILES)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip integration tests unless opt-in or index already cached."""
+    run_integration = os.environ.get("PSDL_RUN_INTEGRATION", "").strip() == "1"
+    index_cached = _index_available()
+
+    if run_integration or index_cached:
+        return  # Let all tests run — don't add any skip markers.
+
+    skip_marker = pytest.mark.skip(
+        reason=(
+            "Integration test skipped: BioLORD v2 index not cached and "
+            "PSDL_RUN_INTEGRATION is not set. "
+            "Run with PSDL_RUN_INTEGRATION=1 to trigger a first-use download (~1.7 GB), "
+            "or set PSDL_VOCAB_SEARCH_DATA_DIR to a local index directory."
+        )
+    )
+    for item in items:
+        if item.get_closest_marker("integration"):
+            item.add_marker(skip_marker)

--- a/backend/psdl_vocab_search/tests/test_biolord_v2.py
+++ b/backend/psdl_vocab_search/tests/test_biolord_v2.py
@@ -86,6 +86,52 @@ def test_preloaded_faiss_retriever_search(tmp_path):
     assert res[0][0] == 100 and res[0][1] > 0.99
 
 
+def test_preloaded_engine_skips_reembed(tmp_path):
+    """PreloadedVocabularySearchEngine must not re-embed; it loads the pre-built index."""
+    import json
+    import numpy as np
+    import faiss
+    import pickle
+    from psdl_vocab_search.factory import PreloadedVocabularySearchEngine
+    from psdl_vocab_search.retrievers import PreloadedFAISSRetriever
+    from psdl_vocab_search.embedders import get_embedder
+    from psdl_vocab_search.rerankers import get_reranker
+
+    # Build a tiny 4-dim index with two concepts.
+    dim = 4
+    emb = np.array([[1.0, 0, 0, 0], [0, 1.0, 0, 0]], dtype=np.float32)
+    idx = faiss.IndexFlatIP(dim)
+    idx.add(emb)
+    index_dir = tmp_path / "idx"
+    index_dir.mkdir()
+    faiss.write_index(idx, str(index_dir / "index.faiss"))
+    with open(index_dir / "index.faiss.meta", "wb") as f:
+        pickle.dump([3016723, 999999], f)
+
+    # Write a minimal vocab JSON.
+    vocab_path = tmp_path / "vocab.json"
+    vocab_path.write_text(json.dumps([
+        {"concept_id": 3016723, "concept_name": "Creatinine [Mass/volume]",
+         "concept_code": "2160-0", "vocabulary_id": "LOINC", "domain_id": "Measurement"},
+        {"concept_id": 999999, "concept_name": "Glucose [Mass/volume]",
+         "concept_code": "2345-7", "vocabulary_id": "LOINC", "domain_id": "Measurement"},
+    ]))
+
+    retriever = PreloadedFAISSRetriever(index_dir=index_dir)
+    engine = PreloadedVocabularySearchEngine(
+        embedder=get_embedder("minilm"),  # will NOT be called during load()
+        retriever=retriever,
+        reranker=get_reranker("rules"),
+        vocab_path=str(vocab_path),
+        cache_dir=str(tmp_path / "cache"),
+    )
+    engine.load()  # should NOT trigger embedding
+
+    assert engine._loaded
+    assert 3016723 in engine._concepts_by_id
+    assert retriever._loaded  # pre-built index is ready
+
+
 # ---------------------------------------------------------------------------
 # Task 6: router import test
 # ---------------------------------------------------------------------------

--- a/backend/psdl_vocab_search/tests/test_biolord_v2.py
+++ b/backend/psdl_vocab_search/tests/test_biolord_v2.py
@@ -30,3 +30,81 @@ def test_build_concept_text_truncation():
     concept = {"concept_name": "Test", "synonyms": [long_synonym], "search_terms": [], "abbreviations": []}
     text = build_concept_text(concept)
     assert len(text) <= 256
+
+
+# ---------------------------------------------------------------------------
+# Task 4: _index_loader tests
+# ---------------------------------------------------------------------------
+
+def test_index_loader_env_override(tmp_path, monkeypatch):
+    from psdl_vocab_search._index_loader import get_index_dir
+    fake_dir = tmp_path / "fake_index"
+    fake_dir.mkdir()
+    for fname in ("metadata.json", "index.faiss", "index.faiss.meta"):
+        (fake_dir / fname).write_bytes(b"sentinel")
+    monkeypatch.setenv("PSDL_VOCAB_SEARCH_DATA_DIR", str(fake_dir))
+    assert get_index_dir() == fake_dir
+
+
+def test_index_loader_cache_hit(tmp_path, monkeypatch):
+    from psdl_vocab_search._index_loader import get_index_dir
+    monkeypatch.delenv("PSDL_VOCAB_SEARCH_DATA_DIR", raising=False)
+    monkeypatch.setenv("PSDL_VOCAB_SEARCH_CACHE_DIR", str(tmp_path))
+    for fname in ("metadata.json", "index.faiss", "index.faiss.meta"):
+        (tmp_path / fname).write_bytes(b"sentinel")
+    assert get_index_dir() == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Task 5: PreloadedFAISSRetriever + SearchEngineConfig.biolord_v2() tests
+# ---------------------------------------------------------------------------
+
+def test_biolord_v2_config_fields():
+    from psdl_vocab_search.factory import SearchEngineConfig
+    cfg = SearchEngineConfig.biolord_v2()
+    assert cfg.embedder == "biolord"
+    assert cfg.retriever == "faiss-preloaded"
+    assert cfg.reranker == "rules"
+
+
+def test_preloaded_faiss_retriever_search(tmp_path):
+    import numpy as np
+    import faiss
+    import pickle
+    from psdl_vocab_search.retrievers import PreloadedFAISSRetriever
+
+    dim = 4
+    emb = np.array([[1.0, 0, 0, 0], [0, 1.0, 0, 0], [0, 0, 1.0, 0]], dtype=np.float32)
+    idx = faiss.IndexFlatIP(dim)
+    idx.add(emb)
+    faiss.write_index(idx, str(tmp_path / "index.faiss"))
+    with open(tmp_path / "index.faiss.meta", "wb") as f:
+        pickle.dump([100, 200, 300], f)
+
+    r = PreloadedFAISSRetriever(index_dir=tmp_path)
+    res = r.search(np.array([1.0, 0, 0, 0], dtype=np.float32), k=2)
+    assert res[0][0] == 100 and res[0][1] > 0.99
+
+
+# ---------------------------------------------------------------------------
+# Task 6: router import test
+# ---------------------------------------------------------------------------
+
+def test_router_imports_biolord_v2_engine():
+    """Verify that get_biolord_v2_engine is importable from the router module."""
+    from app.routers.vocabulary import get_biolord_v2_engine  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Task 7: integration smoke test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_creatinine_top3():
+    from psdl_vocab_search.factory import get_biolord_v2_engine
+    engine = get_biolord_v2_engine()
+    results = engine.search("creatinine", limit=3)
+    ids = [r.concept_id for r in results]
+    assert 3016723 in ids, (
+        f"expected 3016723 in top-3, got {[(r.concept_id, r.concept_name) for r in results]}"
+    )

--- a/backend/psdl_vocab_search/tests/test_biolord_v2.py
+++ b/backend/psdl_vocab_search/tests/test_biolord_v2.py
@@ -1,0 +1,32 @@
+"""Tests for BioLORD v2 index loader and factory preset."""
+import pytest
+
+
+def test_build_concept_text_basic():
+    from build_biolord_embeddings import build_concept_text
+    concept = {
+        "concept_name": "  Creatinine [Mass/volume] in Serum or Plasma  ",
+        "synonyms": ["Creatinine, Blood", None, "Creatinine, Blood"],
+        "search_terms": ["Serum Creatinine"],
+        "abbreviations": ["Crea", "CR"],
+    }
+    text = build_concept_text(concept)
+    assert text.startswith("creatinine [mass/volume] in serum or plasma")
+    assert "none" not in text
+    assert len(text) <= 256
+    assert text.count("creatinine, blood") == 1
+
+
+def test_build_concept_text_no_extras():
+    from build_biolord_embeddings import build_concept_text
+    concept = {"concept_name": "Heart rate", "synonyms": None, "search_terms": None, "abbreviations": None}
+    text = build_concept_text(concept)
+    assert text == "heart rate"
+
+
+def test_build_concept_text_truncation():
+    from build_biolord_embeddings import build_concept_text
+    long_synonym = "x" * 300
+    concept = {"concept_name": "Test", "synonyms": [long_synonym], "search_terms": [], "abbreviations": []}
+    text = build_concept_text(concept)
+    assert len(text) <= 256

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,11 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests that require external data (e.g., BioLORD v2 index); deselect with '-m not integration'",
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"

--- a/backend/scripts/build_biolord_embeddings.py
+++ b/backend/scripts/build_biolord_embeddings.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Build a BioLORD-2023 FAISS index from the vocab-data-v2 vocabulary JSON.
+
+Usage:
+    python scripts/build_biolord_embeddings.py \
+        --vocab ~/.cache/psdl_vocab/v2/vocabulary_final.json \
+        --out /tmp/biolord_build \
+        --batch-size 256
+
+Produces four files in <out_dir>:
+    embeddings.npy         float32 (N, 768) L2-normalised
+    index.faiss            FAISS IndexFlatIP
+    index.faiss.meta       pickle of list[int] concept_ids in row order
+    metadata.json          provenance record (model, dim, text_format, etc.)
+
+A resumable checkpoint <out_dir>/progress.npz is written after every batch and
+removed once the final artefacts are committed.  Re-running the script after an
+interruption picks up from where it left off.
+
+Text format (pinned in metadata.json):
+    concept_name | synonym_1 | synonym_2 | ... | search_term_1 | ... | abbrev_1 | ...
+
+Rules: all fields lowercased and stripped; None values dropped; duplicates removed
+(first-occurrence-wins, order preserved); joined with ' | '; truncated to 256 chars.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import pickle
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+import numpy as np
+
+logging.basicConfig(level=logging.INFO, format="[build] %(message)s")
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Text builder
+# ---------------------------------------------------------------------------
+
+TEXT_FORMAT = "concept_name | synonyms | search_terms | abbreviations"
+TEXT_RULES = (
+    "Lowercase and strip each field value; drop None / falsy entries; "
+    "remove duplicates preserving first-occurrence order; join with ' | '; "
+    "truncate to 256 characters."
+)
+TEXT_CAP = 256
+
+
+def build_concept_text(concept: dict) -> str:
+    """Produce the canonical embedding input string for one concept dict.
+
+    Fields used, in order: concept_name, synonyms (list), search_terms (list),
+    abbreviations (list).  None values and empty strings are skipped.  Duplicates
+    are removed with first-occurrence-wins semantics.  The result is truncated to
+    TEXT_CAP (256) characters.
+    """
+    raw: list[str] = []
+    raw.append(concept.get("concept_name") or "")
+
+    for field in ("synonyms", "search_terms", "abbreviations"):
+        values = concept.get(field)
+        if values is None:
+            continue
+        if isinstance(values, str):
+            raw.append(values)
+        else:
+            raw.extend(v for v in values if v is not None)
+
+    # lowercase + strip, drop falsy
+    parts: list[str] = []
+    seen: set[str] = set()
+    for p in raw:
+        norm = str(p).lower().strip()
+        if not norm:
+            continue
+        if norm in seen:
+            continue
+        seen.add(norm)
+        parts.append(norm)
+
+    text = " | ".join(parts)
+    return text[:TEXT_CAP]
+
+
+# ---------------------------------------------------------------------------
+# Model loader
+# ---------------------------------------------------------------------------
+
+MODEL_ID = "FremyCompany/BioLORD-2023"
+
+
+def _load_model():
+    """Load BioLORD-2023 with MPS → CUDA → CPU device preference."""
+    from sentence_transformers import SentenceTransformer  # type: ignore
+    import torch  # type: ignore
+
+    if torch.backends.mps.is_available():
+        device = "mps"
+    elif torch.cuda.is_available():
+        device = "cuda"
+    else:
+        device = "cpu"
+
+    log.info("Loading %s on %s …", MODEL_ID, device)
+    model = SentenceTransformer(MODEL_ID, device=device)
+    log.info("BioLORD-2023 loaded on %s", device)
+    return model
+
+
+# ---------------------------------------------------------------------------
+# L2 normalisation
+# ---------------------------------------------------------------------------
+
+
+def _normalize(arr: np.ndarray) -> np.ndarray:
+    """L2-normalise rows to unit vectors; return float32."""
+    arr = arr.astype(np.float32)
+    norms = np.linalg.norm(arr, axis=1, keepdims=True)
+    norms = np.where(norms == 0, 1.0, norms)
+    return arr / norms
+
+
+# ---------------------------------------------------------------------------
+# Index builder (resumable)
+# ---------------------------------------------------------------------------
+
+PROGRESS_FILE = "progress.npz"
+
+
+def build_index(concepts: list, out_dir: Path, batch_size: int = 256) -> None:
+    """Embed all concepts into a FAISS IndexFlatIP; write four artefact files.
+
+    Resumable: after each batch the partial results are checkpointed to
+    <out_dir>/progress.npz.  Re-running the script loads the checkpoint and skips
+    already-embedded concepts.
+    """
+    import faiss  # type: ignore
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    progress_path = out_dir / PROGRESS_FILE
+
+    # ---- load checkpoint if present ----------------------------------------
+    done_ids: set[int] = set()
+    saved_embeddings: list[np.ndarray] = []
+    saved_concept_ids: list[int] = []
+
+    if progress_path.exists():
+        try:
+            chk = np.load(progress_path)
+            saved_embeddings = [chk["embeddings"]]
+            saved_concept_ids = list(chk["concept_ids"].tolist())
+            done_ids = set(saved_concept_ids)
+            log.info("Resumed from checkpoint: %d concepts already embedded.", len(done_ids))
+        except Exception as exc:
+            log.warning("Could not load checkpoint (%s); starting fresh.", exc)
+
+    # ---- filter remaining --------------------------------------------------
+    remaining = [c for c in concepts if c["concept_id"] not in done_ids]
+    log.info("%d concepts to embed (%d remaining after checkpoint).", len(concepts), len(remaining))
+
+    # ---- load model (only if there is work to do) --------------------------
+    if remaining:
+        model = _load_model()
+
+        total = len(remaining)
+        for batch_start in range(0, total, batch_size):
+            batch = remaining[batch_start: batch_start + batch_size]
+            texts = [build_concept_text(c) for c in batch]
+            ids = [c["concept_id"] for c in batch]
+
+            embeddings = model.encode(
+                texts,
+                normalize_embeddings=True,
+                show_progress_bar=False,
+                convert_to_numpy=True,
+            ).astype(np.float32)
+
+            saved_embeddings.append(embeddings)
+            saved_concept_ids.extend(ids)
+
+            # checkpoint after each batch (overwrite — atomic-ish on most FS)
+            all_emb_so_far = np.vstack(saved_embeddings)
+            all_ids_so_far = np.array(saved_concept_ids, dtype=np.int64)
+            # write to tmp then rename for better atomicity
+            tmp_progress = out_dir / (PROGRESS_FILE + ".tmp")
+            np.savez(tmp_progress, embeddings=all_emb_so_far, concept_ids=all_ids_so_far)
+            tmp_progress.rename(progress_path)
+
+            done_count = len(saved_concept_ids)
+            pct = done_count / len(concepts) * 100
+            log.info("  %d / %d (%.1f%%)", done_count, len(concepts), pct)
+
+    # ---- finalise artefacts ------------------------------------------------
+    final_embeddings: np.ndarray
+    if saved_embeddings:
+        final_embeddings = np.vstack(saved_embeddings)
+    else:
+        # nothing to embed (all were in checkpoint and no remaining)
+        chk = np.load(progress_path)
+        final_embeddings = chk["embeddings"]
+        saved_concept_ids = list(chk["concept_ids"].tolist())
+
+    # defensive L2-normalise (sentence-transformers normalise_embeddings=True
+    # should have already done this, but guard against edge cases)
+    final_embeddings = _normalize(final_embeddings)
+    log.info("Final matrix: %s dtype=%s", final_embeddings.shape, final_embeddings.dtype)
+
+    dim = final_embeddings.shape[1]
+
+    # FAISS index
+    index = faiss.IndexFlatIP(dim)
+    index.add(final_embeddings)
+
+    # ---- write artefacts ---------------------------------------------------
+    embeddings_path = out_dir / "embeddings.npy"
+    np.save(embeddings_path, final_embeddings)
+    log.info("Wrote %s", embeddings_path)
+
+    index_path = out_dir / "index.faiss"
+    faiss.write_index(index, str(index_path))
+    log.info("Wrote %s", index_path)
+
+    meta_path = out_dir / "index.faiss.meta"
+    with open(meta_path, "wb") as f:
+        pickle.dump(saved_concept_ids, f)
+    log.info("Wrote %s (concept_ids list, %d entries)", meta_path, len(saved_concept_ids))
+
+    metadata = {
+        "model": MODEL_ID,
+        "dimension": dim,
+        "num_concepts": len(saved_concept_ids),
+        "index_type": "IndexFlatIP",
+        "text_format": TEXT_FORMAT,
+        "text_rules": TEXT_RULES,
+        "text_cap_chars": TEXT_CAP,
+        "built_date": datetime.now(timezone.utc).isoformat(),
+        "vocab_source": "vocab-data-v2",
+    }
+    meta_json_path = out_dir / "metadata.json"
+    with open(meta_json_path, "w") as f:
+        json.dump(metadata, f, indent=2)
+    log.info("Wrote %s", meta_json_path)
+
+    # remove progress checkpoint — build is complete
+    if progress_path.exists():
+        progress_path.unlink()
+        log.info("Removed checkpoint %s", progress_path)
+
+
+# ---------------------------------------------------------------------------
+# Tarball packer
+# ---------------------------------------------------------------------------
+
+TARBALL_NAME = "vocab-embeddings-v2-biolord.tar.gz"
+ARTEFACT_FILES = ("embeddings.npy", "index.faiss", "index.faiss.meta", "metadata.json")
+
+
+def pack_tarball(out_dir: Path) -> Path:
+    """Pack the four artefact files into a single .tar.gz in out_dir."""
+    tarball_path = out_dir / TARBALL_NAME
+    with tarfile.open(tarball_path, "w:gz") as tf:
+        for fname in ARTEFACT_FILES:
+            fpath = out_dir / fname
+            if not fpath.exists():
+                raise FileNotFoundError(f"Artefact missing: {fpath}")
+            tf.add(fpath, arcname=fname)
+    size_mb = tarball_path.stat().st_size / (1024 * 1024)
+    log.info("Packed %s (%.1f MB)", tarball_path, size_mb)
+    return tarball_path
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build BioLORD-2023 FAISS embeddings for vocab-data-v2."
+    )
+    parser.add_argument(
+        "--vocab",
+        default=os.path.expanduser("~/.cache/psdl_vocab/v2/vocabulary_final.json"),
+        help="Path to vocabulary_final.json (default: ~/.cache/psdl_vocab/v2/vocabulary_final.json)",
+    )
+    parser.add_argument(
+        "--out",
+        default="/tmp/biolord_build",
+        help="Output directory for artefacts (default: /tmp/biolord_build)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=256,
+        help="Encode batch size (default: 256)",
+    )
+    args = parser.parse_args()
+
+    vocab_path = Path(args.vocab)
+    out_dir = Path(args.out)
+
+    log.info("Loading vocabulary from %s …", vocab_path)
+    with open(vocab_path) as f:
+        concepts = json.load(f)
+    log.info("Loaded %d concepts.", len(concepts))
+
+    build_index(concepts, out_dir, batch_size=args.batch_size)
+    pack_tarball(out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/superpowers/plans/2026-05-29-biolord-reembed-v2.md
+++ b/docs/superpowers/plans/2026-05-29-biolord-reembed-v2.md
@@ -1,0 +1,428 @@
+# BioLORD Re-embed V2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-embed the full 563,138-concept vocabulary (`vocab-data-v2`) using BioLORD-2023, publish the pre-built index as a GitHub Release asset (`vocab-embeddings-v2-biolord`), add a self-contained index loader to `psdl_vocab_search`, add a `SearchEngineConfig.biolord_v2()` factory preset, and replace the two live semantic-search router endpoints that still call `SemanticVocabularyService` (OpenAI, SQLite-based) with the modular `VocabularySearchEngine` backed by BioLORD + `RuleBasedReranker`.
+
+**Architecture:**
+- Offline build script (`backend/scripts/build_biolord_embeddings.py`) runs on Mac MPS in ~47-78 min, writes embeddings in resumable chunks keyed by concept_id.
+- Artifact tarball `vocab-embeddings-v2-biolord.tar.gz` contains four files: `embeddings.npy`, `index.faiss`, `index.faiss.meta`, `metadata.json`. Published to GitHub Release `vocab-embeddings-v2-biolord` on `Chesterguan/psdl-inspector`.
+- New `psdl_vocab_search/_index_loader.py` mirrors `psdl_vocab/_data_loader.py` (env override → cache hit → download). Cache at `~/.cache/psdl_vocab_search/v2-biolord/`.
+- `SearchEngineConfig.biolord_v2()` factory preset wires `BioLORDEmbedder` + `FAISSRetriever` (pre-loaded from downloaded index) + `RuleBasedReranker`.
+- Router replacement: `/api/vocabulary/semantic/search` and `/api/vocabulary/population/search` swap from `get_semantic_vocabulary_service()` to `get_vocabulary_search_engine(SearchEngineConfig.biolord_v2())`.
+
+**Tech Stack:** Python 3.9+, sentence-transformers (`FremyCompany/BioLORD-2023`), FAISS (IndexFlatIP), numpy, FastAPI, PyTorch MPS (Mac) / CPU fallback, GitHub CLI (`gh`).
+
+**Spec reference:** `docs/superpowers/specs/2026-05-21-embedder-comparison.md`
+
+---
+
+## Scope
+
+**In scope:**
+- Build script for BioLORD embeddings (resumable, MPS-accelerated)
+- Compute + pack the four-file artifact tarball
+- GitHub Release publish (tag `vocab-embeddings-v2-biolord`)
+- `psdl_vocab_search/_index_loader.py` — env override / cache / download loader
+- `SearchEngineConfig.biolord_v2()` factory preset + lazy singleton wiring
+- Router swap: replace `SemanticVocabularyService` calls in two endpoints
+- Smoke test: "creatinine" → concept 3016723 in top-3
+- Full `psdl_vocab_search` test suite passes
+
+**Out of scope:**
+- Retraining or fine-tuning BioLORD
+- Changing the `RuleBasedReranker` rules (no new rules in this plan)
+- EmbeddingGemma evaluation (tracked separately in embedder-comparison open items)
+- Workbench adoption (Task #57, separate plan)
+- Removing the old `vocabulary_sqlite.py` service (keep for `/vocabulary/search` text path)
+
+---
+
+## File Structure
+
+| File | Action | Description |
+|------|--------|-------------|
+| `backend/scripts/build_biolord_embeddings.py` | Create | Offline build script — embed + pack artifact |
+| `backend/psdl_vocab_search/_index_loader.py` | Create | Download / cache / env-override loader for pre-built index |
+| `backend/psdl_vocab_search/factory.py` | Edit | Add `biolord_v2()` preset + lazy singleton wiring via loader |
+| `backend/psdl_vocab_search/retrievers.py` | Edit | Add `PreloadedFAISSRetriever` (accepts pre-loaded index, no rebuild) |
+| `backend/app/routers/vocabulary.py` | Edit | Swap two endpoints from `SemanticVocabularyService` to `VocabularySearchEngine` |
+| `backend/psdl_vocab_search/tests/test_biolord_v2.py` | Create | Smoke + integration tests for BioLORD v2 path |
+
+---
+
+## Task 1 — Build script: embed 563k concepts with BioLORD, write resumable chunks, pack tarball
+
+**Files:**
+- Create: `backend/scripts/build_biolord_embeddings.py`
+
+### Input text format (pinned in `metadata.json`)
+
+For each concept, the embedding input is:
+```
+concept_name | synonym_1 | synonym_2 | ... | search_term_1 | ... | abbrev_1 | ...
+```
+Rules: all fields lowercased and stripped; `None` values dropped; duplicates removed (ordered by first appearance); joined with ` | `; truncated to 256 characters.
+
+- [ ] **Step 1: Write failing test for `build_concept_text`** at `backend/psdl_vocab_search/tests/test_biolord_v2.py`
+
+```python
+"""Tests for BioLORD v2 index loader and factory preset."""
+import pytest
+
+
+def test_build_concept_text_basic():
+    from build_biolord_embeddings import build_concept_text
+    concept = {
+        "concept_name": "  Creatinine [Mass/volume] in Serum or Plasma  ",
+        "synonyms": ["Creatinine, Blood", None, "Creatinine, Blood"],
+        "search_terms": ["Serum Creatinine"],
+        "abbreviations": ["Crea", "CR"],
+    }
+    text = build_concept_text(concept)
+    assert text.startswith("creatinine [mass/volume] in serum or plasma")
+    assert "none" not in text
+    assert len(text) <= 256
+    assert text.count("creatinine, blood") == 1
+
+
+def test_build_concept_text_no_extras():
+    from build_biolord_embeddings import build_concept_text
+    concept = {"concept_name": "Heart rate", "synonyms": None, "search_terms": None, "abbreviations": None}
+    text = build_concept_text(concept)
+    assert text == "heart rate"
+
+
+def test_build_concept_text_truncation():
+    from build_biolord_embeddings import build_concept_text
+    long_synonym = "x" * 300
+    concept = {"concept_name": "Test", "synonyms": [long_synonym], "search_terms": [], "abbreviations": []}
+    text = build_concept_text(concept)
+    assert len(text) <= 256
+```
+
+Run:
+```bash
+cd /Volumes/extraSupply/Projects/psdl-inspector/backend && source .venv/bin/activate
+PYTHONPATH=scripts pytest psdl_vocab_search/tests/test_biolord_v2.py::test_build_concept_text_basic -x 2>&1 | tail -5
+```
+Expected: `ModuleNotFoundError: No module named 'build_biolord_embeddings'`.
+
+- [ ] **Step 2: Create `backend/scripts/build_biolord_embeddings.py`** (full source — see the implementation listed in the operator handoff section below; the writing-plans skill embeds it inline here, or refer to the canonical version under git history)
+
+The script does:
+- `build_concept_text(concept)` — produces the canonical input text per the format above.
+- `_load_model()` — loads `FremyCompany/BioLORD-2023` with MPS → CUDA → CPU fallback.
+- `build_index(concepts, out_dir, batch_size)` — resumable per-batch checkpoint to `progress.npz`; final FAISS `IndexFlatIP` (768-dim normalized vectors); writes `embeddings.npy`, `index.faiss`, `index.faiss.meta` (pickle of `list[int]` concept_ids in row order), `metadata.json` (model, dim, num_concepts, text_format, text_rules, built_date, vocab_source).
+- `pack_tarball(out_dir)` — packs all four files into `vocab-embeddings-v2-biolord.tar.gz`.
+- `main()` — argparse `--vocab`, `--out`, `--batch-size` (default 256). Defaults the vocab path to `~/.cache/psdl_vocab/v2/vocabulary_final.json`.
+
+- [ ] **Step 3: Run text-builder tests — expect pass**
+
+```bash
+PYTHONPATH=scripts pytest psdl_vocab_search/tests/test_biolord_v2.py -v -k build_concept_text 2>&1 | tail -10
+```
+Expected: 3 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Volumes/extraSupply/Projects/psdl-inspector
+git add backend/scripts/build_biolord_embeddings.py backend/psdl_vocab_search/tests/test_biolord_v2.py
+git commit -m "feat(vocab): add BioLORD v2 build script + concept_text tests"
+```
+
+---
+
+## Task 2 — Operator compute: run the build script, verify tarball
+
+> **Human-gated step** — the agent cannot run a 47-78 min MPS job. Execute manually, then continue.
+
+- [ ] **Step 1: Install deps + run the build (resumable; re-running picks up the checkpoint)**
+
+```bash
+cd /Volumes/extraSupply/Projects/psdl-inspector/backend && source .venv/bin/activate
+pip install sentence-transformers faiss-cpu torch --quiet
+time python scripts/build_biolord_embeddings.py \
+    --vocab ~/.cache/psdl_vocab/v2/vocabulary_final.json \
+    --out /tmp/biolord_build \
+    --batch-size 256
+```
+Expected: `[build] BioLORD-2023 loaded on mps` → progress bar to 100% → `Final matrix: (563138, 768)` → `Packed /tmp/biolord_build/vocab-embeddings-v2-biolord.tar.gz`.
+
+- [ ] **Step 2: Verify artifact integrity**
+
+```bash
+tar -tzf /tmp/biolord_build/vocab-embeddings-v2-biolord.tar.gz
+python3 -c "
+import json, numpy as np
+emb = np.load('/tmp/biolord_build/embeddings.npy')
+print('shape:', emb.shape, 'dtype:', emb.dtype)
+meta = json.load(open('/tmp/biolord_build/metadata.json'))
+print('model:', meta['model'], 'concepts:', meta['num_concepts'])
+norms = np.linalg.norm(emb[:100], axis=1)
+print('norm range:', norms.min(), '-', norms.max())  # ~1.0
+"
+```
+Expected: `(563138, 768)`, model = `FremyCompany/BioLORD-2023`, norms ~1.0.
+
+---
+
+## Task 3 — Publish GitHub Release asset
+
+> **Human-gated step** — requires GitHub credentials.
+
+- [ ] **Step 1: Create the release**
+
+```bash
+gh release create vocab-embeddings-v2-biolord \
+    --repo Chesterguan/psdl-inspector \
+    --title "BioLORD v2 Embeddings (563k concepts)" \
+    --notes "Pre-built FAISS IndexFlatIP embeddings for vocab-data-v2 using FremyCompany/BioLORD-2023. 768-dim, normalized. Text format: concept_name | synonyms | search_terms | abbreviations (lowercased, stripped, deduped, capped 256)." \
+    /tmp/biolord_build/vocab-embeddings-v2-biolord.tar.gz
+```
+
+- [ ] **Step 2: Record the asset URL** (used in `_index_loader.py`)
+
+```bash
+gh release view vocab-embeddings-v2-biolord --repo Chesterguan/psdl-inspector --json assets --jq '.assets[].browserDownloadUrl'
+```
+Expect: `https://github.com/Chesterguan/psdl-inspector/releases/download/vocab-embeddings-v2-biolord/vocab-embeddings-v2-biolord.tar.gz`
+
+---
+
+## Task 4 — `_index_loader.py`: env override / cache / download
+
+**Files:**
+- Create: `backend/psdl_vocab_search/_index_loader.py`
+
+- [ ] **Step 1: Write failing tests** — see `tests/test_biolord_v2.py`:
+
+```python
+def test_index_loader_env_override(tmp_path, monkeypatch):
+    from psdl_vocab_search._index_loader import get_index_dir
+    fake_dir = tmp_path / "fake_index"
+    fake_dir.mkdir()
+    for fname in ("metadata.json", "index.faiss", "index.faiss.meta", "embeddings.npy"):
+        (fake_dir / fname).write_bytes(b"sentinel")
+    monkeypatch.setenv("PSDL_VOCAB_SEARCH_DATA_DIR", str(fake_dir))
+    assert get_index_dir() == fake_dir
+
+
+def test_index_loader_cache_hit(tmp_path, monkeypatch):
+    from psdl_vocab_search._index_loader import get_index_dir
+    monkeypatch.delenv("PSDL_VOCAB_SEARCH_DATA_DIR", raising=False)
+    monkeypatch.setenv("PSDL_VOCAB_SEARCH_CACHE_DIR", str(tmp_path))
+    for fname in ("metadata.json", "index.faiss", "index.faiss.meta", "embeddings.npy"):
+        (tmp_path / fname).write_bytes(b"sentinel")
+    assert get_index_dir() == tmp_path
+```
+
+- [ ] **Step 2: Create the loader** at `backend/psdl_vocab_search/_index_loader.py` mirroring `psdl_vocab/_data_loader.py`:
+
+```python
+"""Resolve the directory containing the pre-built BioLORD v2 FAISS index.
+
+Resolution order:
+1. PSDL_VOCAB_SEARCH_DATA_DIR env var (offline override)
+2. Cache hit at PSDL_VOCAB_SEARCH_CACHE_DIR (default ~/.cache/psdl_vocab_search/v2-biolord/)
+3. Download tarball from the pinned GitHub Release, unpack atomically into the cache dir.
+
+Required artifact files: embeddings.npy, index.faiss, index.faiss.meta, metadata.json.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import ssl
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+INDEX_VERSION = "v2-biolord"
+INDEX_TARBALL_URL = (
+    "https://github.com/Chesterguan/psdl-inspector/releases/download/"
+    "vocab-embeddings-v2-biolord/vocab-embeddings-v2-biolord.tar.gz"
+)
+REQUIRED_FILES = ("embeddings.npy", "index.faiss", "index.faiss.meta", "metadata.json")
+
+
+def _cache_dir() -> Path:
+    override = os.environ.get("PSDL_VOCAB_SEARCH_CACHE_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / ".cache" / "psdl_vocab_search" / INDEX_VERSION
+
+
+def _all_present(directory: Path) -> bool:
+    return all((directory / f).exists() for f in REQUIRED_FILES)
+
+
+def _ssl_context() -> ssl.SSLContext:
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
+def _download_and_unpack(cache_dir: Path) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(prefix=".biolord-", suffix=".tar.gz", dir=str(cache_dir))
+    os.close(tmp_fd)
+    tmp_tarball = Path(tmp_name)
+    try:
+        print("[psdl_vocab_search] Downloading BioLORD v2 index ...", flush=True)
+        with urllib.request.urlopen(INDEX_TARBALL_URL, context=_ssl_context()) as resp, open(tmp_tarball, "wb") as out:
+            shutil.copyfileobj(resp, out)
+        tmp_unpack = cache_dir / ".unpack_tmp"
+        if tmp_unpack.exists():
+            shutil.rmtree(tmp_unpack)
+        tmp_unpack.mkdir()
+        with tarfile.open(tmp_tarball, "r:gz") as tf:
+            tf.extractall(str(tmp_unpack))
+        for fname in REQUIRED_FILES:
+            src, dst = tmp_unpack / fname, cache_dir / fname
+            if src.exists():
+                os.replace(src, dst)
+        shutil.rmtree(tmp_unpack, ignore_errors=True)
+        print(f"[psdl_vocab_search] Index cached at {cache_dir}", flush=True)
+    except (urllib.error.URLError, OSError, EOFError, tarfile.TarError) as exc:
+        raise RuntimeError(
+            f"psdl_vocab_search could not download the BioLORD v2 index from {INDEX_TARBALL_URL} ({exc}). "
+            "For offline installs set PSDL_VOCAB_SEARCH_DATA_DIR to a directory containing the four artifact files."
+        ) from exc
+    finally:
+        try:
+            tmp_tarball.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def get_index_dir() -> Path:
+    override = os.environ.get("PSDL_VOCAB_SEARCH_DATA_DIR")
+    if override:
+        p = Path(override)
+        if not p.is_dir():
+            raise RuntimeError(f"PSDL_VOCAB_SEARCH_DATA_DIR={override!r} is not a directory")
+        if not _all_present(p):
+            missing = [f for f in REQUIRED_FILES if not (p / f).exists()]
+            raise RuntimeError(f"PSDL_VOCAB_SEARCH_DATA_DIR={override!r} is missing files: {missing}")
+        return p
+    cache_dir = _cache_dir()
+    if _all_present(cache_dir):
+        return cache_dir
+    _download_and_unpack(cache_dir)
+    return cache_dir
+```
+
+- [ ] **Step 3: Run loader tests — expect 2 passed.**
+- [ ] **Step 4: Commit:** `git add ... && git commit -m "feat(vocab-search): add _index_loader for BioLORD v2 pre-built index"`
+
+---
+
+## Task 5 — `PreloadedFAISSRetriever` + `SearchEngineConfig.biolord_v2()` factory preset
+
+**Files:**
+- Edit: `backend/psdl_vocab_search/retrievers.py` (add `PreloadedFAISSRetriever`, register in `RETRIEVER_REGISTRY` under key `"faiss-preloaded"`)
+- Edit: `backend/psdl_vocab_search/factory.py` (add `SearchEngineConfig.biolord_v2()` classmethod + module-level `get_biolord_v2_engine()` singleton accessor)
+
+`PreloadedFAISSRetriever`: subclass of `BaseRetriever` whose `_ensure_loaded()` calls `_index_loader.get_index_dir()` (or accepts an injected `index_dir` for tests), reads `index.faiss` with `faiss.read_index` + `index.faiss.meta` (pickle of `list[int]`). `build_index` is a no-op (pre-built). `search(query_embedding, k)` returns `[(concept_id, score), ...]` mapping FAISS row indices back via the stored concept_ids list. TDD tests:
+
+```python
+def test_biolord_v2_config_fields():
+    from psdl_vocab_search.factory import SearchEngineConfig
+    cfg = SearchEngineConfig.biolord_v2()
+    assert cfg.embedder == "biolord"
+    assert cfg.retriever == "faiss-preloaded"
+    assert cfg.reranker == "rules"
+
+
+def test_preloaded_faiss_retriever_search(tmp_path):
+    import numpy as np, faiss, pickle
+    from psdl_vocab_search.retrievers import PreloadedFAISSRetriever
+    dim = 4
+    emb = np.array([[1.0,0,0,0],[0,1.0,0,0],[0,0,1.0,0]], dtype=np.float32)
+    idx = faiss.IndexFlatIP(dim); idx.add(emb)
+    faiss.write_index(idx, str(tmp_path/"index.faiss"))
+    with open(tmp_path/"index.faiss.meta","wb") as f:
+        pickle.dump([100,200,300], f)
+    r = PreloadedFAISSRetriever(index_dir=tmp_path)
+    res = r.search(np.array([1.0,0,0,0], dtype=np.float32), k=2)
+    assert res[0][0] == 100 and res[0][1] > 0.99
+```
+
+Commit: `feat(vocab-search): PreloadedFAISSRetriever + SearchEngineConfig.biolord_v2() preset`.
+
+---
+
+## Task 6 — Router replacement: SemanticVocabularyService → VocabularySearchEngine
+
+**Files:**
+- Edit: `backend/app/routers/vocabulary.py`
+
+Target endpoints:
+- `GET /vocabulary/semantic/search`
+- `GET /vocabulary/population/search` (filter results by `vocabulary_id` for `type=conditions` → SNOMED / `type=medications` → RxNorm)
+
+Pattern: try BioLORD via `get_biolord_v2_engine()` first; on any exception (engine error), fall back to the legacy `SemanticVocabularyService` *if available*; else raise. Keep `SemanticVocabularyService` import + the `/vocabulary/population/concept/{concept_id}` + `/vocabulary/population/stats` routes (still used) intact.
+
+Add a test asserting `get_biolord_v2_engine` is importable from the router module after the swap.
+
+Commit: `feat(router): swap /semantic/search + /population/search to BioLORD v2 engine`.
+
+---
+
+## Task 7 — Smoke test: "creatinine" → concept 3016723 in top-3
+
+```python
+import pytest
+
+@pytest.mark.integration
+def test_creatinine_top3():
+    from psdl_vocab_search.factory import get_biolord_v2_engine
+    engine = get_biolord_v2_engine()
+    results = engine.search("creatinine", limit=3)
+    ids = [r.concept_id for r in results]
+    assert 3016723 in ids, f"expected 3016723 in top-3, got {[(r.concept_id, r.concept_name) for r in results]}"
+```
+
+If this fails, the BioLORD + reranker stack isn't doing what the comparison study claimed — investigate before declaring V2 done.
+
+Commit: `test(vocab-search): add creatinine smoke test (integration, requires index)`.
+
+---
+
+## Task 8 — Integration marker + full suite green
+
+- Register an `integration` marker in `backend/pyproject.toml` under `[tool.pytest.ini_options]`.
+- Add `backend/psdl_vocab_search/tests/conftest.py` with a `pytest_collection_modifyitems` hook that skips integration tests unless `PSDL_RUN_INTEGRATION=1` OR the BioLORD cache exists OR `PSDL_VOCAB_SEARCH_DATA_DIR` is set.
+- Run `pytest psdl_vocab_search/tests/ -m "not integration" -v` — all green; integration tests skipped with reason.
+- Run `PSDL_RUN_INTEGRATION=1 pytest psdl_vocab_search/tests/ -v` — including the creatinine smoke test green.
+
+Commit: `test(vocab-search): integration marker + conftest skip guard for BioLORD tests`.
+
+---
+
+## Self-Review
+
+| Check | Command | Expected |
+|---|---|---|
+| Unit tests pass | `pytest psdl_vocab_search/tests/ -m "not integration" -v` | All green |
+| Integration smoke | `PSDL_RUN_INTEGRATION=1 pytest .../test_creatinine_top3 -v` | 3016723 in top-3 |
+| Router imports clean | `python -c "from app.routers.vocabulary import router"` | No ImportError |
+| Loader env override | covered in unit tests | green |
+| Tarball integrity | check `metadata.json`'s `num_concepts` is 563138 | matches |
+| Legacy fallback preserved | `BIOLORD_AVAILABLE=False` path still hits `SemanticVocabularyService` | review router diff |
+
+---
+
+## Execution Handoff
+
+**Subagent-driven (recommended for Tasks 1, 4, 5, 6, 7, 8)** — Tasks 2 + 3 are explicit human gates (operator runs the 47-78 min compute + `gh release create`). The agent implements 1, 4, 5, 6, 7, 8 in order, pauses at Task 2 with a BLOCKERS note, and resumes once the operator confirms the release URL is live.
+
+**Inline (single session)** — same flow, manual gates marked in BLOCKERS.md when Task 2 is reached.
+
+Run the Self-Review checklist before declaring the branch ready for PR.


### PR DESCRIPTION
## Summary

Wires the published **BioLORD v2** embeddings release into `psdl_vocab_search` and swaps the live vocabulary endpoints to use it (Track B Tasks 4-8 of the BioLORD re-embed plan; Tasks 1-3 build script already on the branch).

Release asset: `vocab-embeddings-v2-biolord` (slim tarball — `index.faiss` + `index.faiss.meta` + `metadata.json`; `embeddings.npy` excluded, recoverable via FAISS `reconstruct()`).

## Changes (5 commits past main)

- **`_index_loader.py`** — env override → cache (`~/.cache/psdl_vocab_search/v2-biolord/`) → download from the release URL. Slim `REQUIRED_FILES = (index.faiss, index.faiss.meta, metadata.json)`; certifi SSL context.
- **`PreloadedFAISSRetriever`** in `retrievers.py` (registered `"faiss-preloaded"` in `RETRIEVER_REGISTRY`).
- **`SearchEngineConfig.biolord_v2()`** + module-level `get_biolord_v2_engine()` + `PreloadedVocabularySearchEngine` in `factory.py`.
- **Router swap** — `/semantic/search` + `/population/search` in `app/routers/vocabulary.py` now use `get_biolord_v2_engine()`, with graceful fallback if `psdl_vocab_search` is unavailable.
- **Tests** — `@pytest.mark.integration test_creatinine_top3` + `integration` marker (pyproject) + conftest skip guard (mirrors the V1a Synthea integration pattern).

## Verification

- **Unit tests** (`-m "not integration"`): 9 passed.
- **Integration smoke test** (`PSDL_RUN_INTEGRATION=1`, run in isolation): PASSED.
- **"creatinine" top-3:**
  - `19071968` — creatinine (RxNorm)
  - **`3016723` — Creatinine [Mass/volume] in Serum or Plasma (LOINC) ← target, position 2**
  - `3013073` — Creatinine [Mass/volume] in Vitreous fluid (LOINC)

Target concept `3016723` confirmed in top-3 — the BioLORD-effect signal.

## Caveat (macOS, tests only — benign in production)

Running the full `psdl_vocab_search` suite in a single pytest session aborts with SIGABRT on macOS Python 3.9 ARM: FAISS (unit tests) and torch (integration test) conflict over the Accelerate framework when loaded into the same process. **Run the integration test in its own invocation.** Production is unaffected — the FastAPI server loads torch before FAISS, so the safe load order holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)