### PR TITLE
feat(anchoring): env-gated ANCHORING_ENGINE selector (enables embedder A/B)

### DIFF
--- a/backend/psdl_anchoring/service.py
+++ b/backend/psdl_anchoring/service.py
@@ -13,6 +13,7 @@ Last updated: 2026-05-22
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from typing import Dict, List, Any, Optional, Set
 
@@ -24,10 +25,29 @@ from psdl_vocab import get_vocabulary_service
 # Try to import modular search system (preferred)
 _modular_search_available = False
 try:
-    from psdl_vocab_search import get_vocabulary_search_engine, SearchEngineConfig
+    from psdl_vocab_search import (
+        get_vocabulary_search_engine,
+        get_biolord_v2_engine,
+        SearchEngineConfig,
+    )
     _modular_search_available = True
 except ImportError:
     pass
+
+
+def _get_anchoring_engine():
+    """Select the vocabulary search engine used by the modular anchoring path.
+
+    Env-gated experiment toggle (default unchanged):
+      ANCHORING_ENGINE=biolord_v2  -> the BioLORD v2 preset (get_biolord_v2_engine)
+      anything else / unset        -> the default engine (get_vocabulary_search_engine)
+
+    Lets the eval-report A/B the embedder while keeping production behavior the
+    same until BioLORD is proven better; reversible by unsetting the env var.
+    """
+    if os.environ.get("ANCHORING_ENGINE") == "biolord_v2":
+        return get_biolord_v2_engine()
+    return get_vocabulary_search_engine()
 
 
 class TerminologyAnchoringService:
@@ -189,7 +209,7 @@ class TerminologyAnchoringService:
         omop_domain: Optional[str] = None,
     ) -> TerminologyAnchor:
         """Anchor using modular search engine (configurable embedder/retriever/reranker)."""
-        search_engine = get_vocabulary_search_engine()
+        search_engine = _get_anchoring_engine()
 
         # Build search query
         search_query = ref_spaced

--- a/backend/psdl_anchoring/tests/test_engine_selection.py
+++ b/backend/psdl_anchoring/tests/test_engine_selection.py
@@ -1,0 +1,63 @@
+"""Tests for the env-gated anchoring engine selector (ANCHORING_ENGINE)."""
+
+from types import SimpleNamespace
+
+from psdl_anchoring import service as svc
+
+
+def test_selector_defaults_to_vocabulary_search_engine(monkeypatch):
+    monkeypatch.delenv("ANCHORING_ENGINE", raising=False)
+    sentinel_default = object()
+    monkeypatch.setattr(svc, "get_vocabulary_search_engine", lambda: sentinel_default)
+    monkeypatch.setattr(svc, "get_biolord_v2_engine", lambda: object())
+    assert svc._get_anchoring_engine() is sentinel_default
+
+
+def test_selector_returns_biolord_when_env_set(monkeypatch):
+    monkeypatch.setenv("ANCHORING_ENGINE", "biolord_v2")
+    sentinel_biolord = object()
+    monkeypatch.setattr(svc, "get_vocabulary_search_engine", lambda: object())
+    monkeypatch.setattr(svc, "get_biolord_v2_engine", lambda: sentinel_biolord)
+    assert svc._get_anchoring_engine() is sentinel_biolord
+
+
+def test_selector_unknown_value_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("ANCHORING_ENGINE", "bogus")
+    sentinel_default = object()
+    monkeypatch.setattr(svc, "get_vocabulary_search_engine", lambda: sentinel_default)
+    monkeypatch.setattr(svc, "get_biolord_v2_engine", lambda: object())
+    assert svc._get_anchoring_engine() is sentinel_default
+
+
+def test_modular_search_goes_through_selector(monkeypatch):
+    """_anchor_with_modular_search must use the selector, not a hardcoded factory.
+
+    Uses a fake engine (no model load) so this verifies wiring only. Thresholds
+    are unchanged: final_score 1.0 -> 'high'.
+    """
+    service = svc.TerminologyAnchoringService()
+
+    class _Res:
+        concept_id = 3016723
+        concept_code = "2160-0"
+        vocabulary_id = "LOINC"
+        concept_name = "Creatinine [Mass/volume] in Serum or Plasma"
+        domain_id = "Measurement"
+        final_score = 1.0
+
+    fake_engine = SimpleNamespace(
+        search=lambda q, limit=5, domain=None: [_Res()],
+        get_by_id=lambda cid: {},
+    )
+    used = {}
+
+    def _select():
+        used["called"] = True
+        return fake_engine
+
+    monkeypatch.setattr(svc, "_get_anchoring_engine", _select)
+    anchor = service._anchor_with_modular_search("creatinine", "creatinine", "Measurement")
+
+    assert used.get("called") is True
+    assert anchor.concept_id == 3016723
+    assert anchor.match_confidence == "high"

--- a/backend/psdl_vocab_search/__init__.py
+++ b/backend/psdl_vocab_search/__init__.py
@@ -17,6 +17,7 @@ from psdl_vocab_search.base import (
 )
 from psdl_vocab_search.factory import (
     get_vocabulary_search_engine,
+    get_biolord_v2_engine,
     create_search_engine,
     SearchEngineConfig,
     list_available_components,
@@ -30,6 +31,7 @@ __all__ = [
     "BaseReranker",
     "VocabularySearchEngine",
     "get_vocabulary_search_engine",
+    "get_biolord_v2_engine",
     "create_search_engine",
     "SearchEngineConfig",
     "list_available_components",


### PR DESCRIPTION
## Summary

Adds an env-gated engine selector to the anchoring path so the eval-report can A/B the embedder without changing production behavior:

- `psdl_anchoring.service._get_anchoring_engine()` — `ANCHORING_ENGINE=biolord_v2` selects `get_biolord_v2_engine()`, anything else / unset uses the current default (`get_vocabulary_search_engine()`, minilm). `_anchor_with_modular_search` now goes through the selector instead of the hardcoded factory.
- Exports `get_biolord_v2_engine` from the `psdl_vocab_search` package (`__init__.py`).

Default path is byte-for-byte unchanged → production, existing tests unaffected. Reversible by unsetting the env var. Score→confidence thresholds intentionally untouched (held constant so the A/B isolates the embedder).

## Why: A/B result (minilm vs BioLORD v2 in the anchoring path)

Run via the Workbench eval-report against the 70-pair `mapping_gold` (identical `gold_version`, thresholds constant):

| Metric | minilm | BioLORD v2 | Δ |
|---|---|---|---|
| precision_at_1 / mrr | 0.414 | 0.343 | ▼ −0.071 |
| auto_accept_correct_pct (accuracy_high) | 41.4% | 46.5% | ▲ +5.1 |
| accuracy_medium | — (single tier) | 14.8% | new tier |
| expected_calibration_error | 55.6 | 54.2 | ▲ −1.3 |
| candidate_coverage / unanchored_rate | 100% / 0% | 100% / 0% | 0 |

**Finding:** BioLORD is *not* a clear win. Top-1 accuracy regressed ~7 points, but calibration improved — "high" is more trustworthy (46.5% vs 41.4%) and BioLORD stops labeling everything "high" (real medium tier appears, correctly less accurate). Caveat: thresholds were minilm-tuned, so part of the calibration shift is the fixed cutoffs meeting BioLORD's different score distribution. **Conclusion: the embedder alone isn't the lever — the bottleneck is the ranker + confidence thresholds.** The selector stays as the toggle that will measure those next experiments.

## Test plan

- [x] `psdl_anchoring/tests/test_engine_selection.py` — 4 tests: selector default / biolord_v2 / unknown-value-fallback / `_anchor_with_modular_search` goes through the selector. All pass.
- [x] Existing `test_terminology_anchoring.py` — 5 passed (no regression; default path unchanged).
- [x] Default-path import intact: `_modular_search_available = True`, `get_biolord_v2_engine` exported.
- [x] A/B run end-to-end (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)